### PR TITLE
bump up versions and fix apis to work with python 3.14

### DIFF
--- a/gui/components/console.py
+++ b/gui/components/console.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components.rounded_frame import RoundedFrame
 from gui.helpers.images import Images
 from gui.helpers.style import Style
@@ -85,7 +86,7 @@ class Console:
         if self.avatar:
             avatar_label = ttk.Label(wrapper, image=self.avatar)
             avatar_label.configure(background=self.root.style.colors.get("secondary"))
-            avatar_label.grid(row=0, column=0, sticky=ttk.W, padx=(10, 5), pady=5)
+            avatar_label.grid(row=0, column=0, sticky=W, padx=(10, 5), pady=5)
         
         username = ttk.Label(wrapper, text=f"Logged in as {user.name}" if user else "Failed to get user info...", font=("Host Grotesk", 12, "italic"))
         username.configure(background=self.root.style.colors.get("secondary"))

--- a/gui/components/dropdown_menu.py
+++ b/gui/components/dropdown_menu.py
@@ -1,4 +1,5 @@
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components import RoundedFrame
 from gui.helpers.style import Style
 
@@ -44,11 +45,11 @@ class DropdownMenu:
             index += 1
             
             wrapper = RoundedFrame(self.frame, radius=8, background=self.parent.style.colors.get("secondary"))
-            wrapper.pack(fill=ttk.X, padx=5, pady=(4, 5 if index == len(self.options) else 0))
+            wrapper.pack(fill=X, padx=5, pady=(4, 5 if index == len(self.options) else 0))
             wrapper.bind("<Button-1>", lambda e, opt=option: self._on_option_selected(opt))
             
             label = ttk.Label(wrapper, text=option, background=self.parent.style.colors.get("secondary"), anchor="w")
-            label.pack(fill=ttk.X, padx=5, pady=2)
+            label.pack(fill=X, padx=5, pady=2)
             label.bind("<Button-1>", lambda e, opt=option: self._on_option_selected(opt))
             
             label.bind("<Enter>", lambda e, w=wrapper, l=label: self._hover_enter(w, l))
@@ -64,7 +65,7 @@ class DropdownMenu:
             widget.destroy()
             
         label = ttk.Label(self.frame, textvariable=self.selected_option, anchor="w", background=self.parent.style.colors.get("secondary"))
-        label.pack(fill=ttk.X, padx=10, pady=5)
+        label.pack(fill=X, padx=10, pady=5)
         label.bind("<Button-1>", self._open_menu)
         self.frame.bind("<Button-1>", self._open_menu)
         
@@ -94,7 +95,7 @@ class DropdownMenu:
         self.frame = RoundedFrame(self.parent, radius=5, bootstyle="secondary.TFrame")
 
         label = ttk.Label(self.frame, textvariable=self.selected_option, anchor="w", background=self.style.colors.get("secondary"))
-        label.pack(fill=ttk.X, padx=10, pady=5)
+        label.pack(fill=X, padx=10, pady=5)
         label.bind("<Button-1>", self._open_menu)
         self.frame.bind("<Button-1>", self._open_menu)
         

--- a/gui/components/rounded_button.py
+++ b/gui/components/rounded_button.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components import RoundedFrame
 
 class RoundedButton(ttk.Canvas):
@@ -28,11 +29,11 @@ class RoundedButton(ttk.Canvas):
 
         # Create the rounded frame
         self.frame = RoundedFrame(self, radius=radius, bootstyle=bootstyle, background=self.original_bg)
-        self.frame.pack(fill=ttk.BOTH)
+        self.frame.pack(fill=BOTH)
 
         # Create the label inside the rounded frame
         self.button = ttk.Label(self.frame, text=text, image=image, style=bootstyle, anchor="center", borderwidth=0, relief="flat", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13) if not kwargs.get("font") else kwargs.get("font"), foreground=self.foreground)
-        self.button.pack(fill=ttk.BOTH, expand=True, padx=self.padx, pady=self.pady)
+        self.button.pack(fill=BOTH, expand=True, padx=self.padx, pady=self.pady)
 
         # Bind events for clicking
         if command:

--- a/gui/components/settings/apis.py
+++ b/gui/components/settings/apis.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import utils.console as console
 from gui.components import SettingsPanel
 
@@ -21,7 +22,7 @@ class APIsPanel(SettingsPanel):
         
     def draw(self):
         wrapper = ttk.Frame(self.body, style="dark.TFrame")
-        wrapper.pack(fill=ttk.BOTH, expand=True, padx=10, pady=10)
+        wrapper.pack(fill=BOTH, expand=True, padx=10, pady=10)
         wrapper.grid_columnconfigure(1, weight=1)
         
         for index, (key, value) in enumerate(self.api_keys_entries.items()):
@@ -35,12 +36,12 @@ class APIsPanel(SettingsPanel):
             label = ttk.Label(wrapper, text=value)
             label.configure(background=self.root.style.colors.get("dark"))
 
-            label.grid(row=index + 1, column=0, sticky=ttk.W, padx=(0, 10), pady=(0, 2))
+            label.grid(row=index + 1, column=0, sticky=W, padx=(0, 10), pady=(0, 2))
             entry.grid(row=index + 1, column=1, sticky="we", pady=(0, 2))
 
             self.api_keys_tk_entries[key] = entry
 
         # save_api_keys_button = ttk.Button(self.body, text="Save", style="success.TButton", command=self._save_api_keys)
-        # save_api_keys_button.grid(row=len(self.api_keys_entries) + 1, column=2, sticky=ttk.E, padx=(0, 11), pady=10)
+        # save_api_keys_button.grid(row=len(self.api_keys_entries) + 1, column=2, sticky=E, padx=(0, 11), pady=10)
         
         return self.wrapper

--- a/gui/components/settings/general.py
+++ b/gui/components/settings/general.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import utils.console as console
 from gui.components import SettingsPanel, DropdownMenu, RoundedButton
 from gui.helpers import apply_theme, get_themes
@@ -82,7 +83,7 @@ class GeneralPanel(SettingsPanel):
             label = ttk.Label(self.body, text=value)
             label.configure(background=self.root.style.colors.get("dark"))
 
-            label.grid(row=index + 1, column=0, sticky=ttk.W, padx=padding[0], pady=padding[1])
+            label.grid(row=index + 1, column=0, sticky=W, padx=padding[0], pady=padding[1])
             entry.grid(row=index + 1, column=1, sticky="we", padx=padding[0], pady=padding[1], columnspan=3)
 
             self.body.grid_columnconfigure(1, weight=1)
@@ -90,7 +91,7 @@ class GeneralPanel(SettingsPanel):
         
         message_style_label = ttk.Label(self.body, text="Message style")
         message_style_label.configure(background=self.root.style.colors.get("dark"))
-        message_style_label.grid(row=len(self.config_entries) + 1, column=0, sticky=ttk.NW, padx=(10, 0), pady=(5, 10))
+        message_style_label.grid(row=len(self.config_entries) + 1, column=0, sticky=NW, padx=(10, 0), pady=(5, 10))
         
         self.message_style_entry = DropdownMenu(self.body, options=["codeblock", "image", "embed"], command=self._set_message_style)
         self.message_style_entry.set_selected(self.cfg.get("message_settings.style"))
@@ -98,7 +99,7 @@ class GeneralPanel(SettingsPanel):
         
         gui_theme_label = ttk.Label(self.body, text="GUI Theme")
         gui_theme_label.configure(background=self.root.style.colors.get("dark"))
-        gui_theme_label.grid(row=len(self.config_entries) + 2, column=0, sticky=ttk.NW, padx=(10, 0), pady=(5, 10))
+        gui_theme_label.grid(row=len(self.config_entries) + 2, column=0, sticky=NW, padx=(10, 0), pady=(5, 10))
         
         self.gui_theme_entry = DropdownMenu(self.body, options=get_themes(), command=lambda _: self._set_gui_theme())
         self.gui_theme_entry.set_selected(self.cfg.get("gui_theme"))
@@ -106,11 +107,11 @@ class GeneralPanel(SettingsPanel):
         
         edit_og_msg_label = ttk.Label(self.body, text="Edit original message")
         edit_og_msg_label.configure(background=self.root.style.colors.get("dark"))
-        edit_og_msg_label.grid(row=len(self.config_entries) + 3, column=0, sticky=ttk.NW, padx=(10, 0), pady=(2, 10))
+        edit_og_msg_label.grid(row=len(self.config_entries) + 3, column=0, sticky=NW, padx=(10, 0), pady=(2, 10))
         
         self.edit_og_msg_entry = ttk.Checkbutton(self.body, command=self._save_cfg, style="success-round-toggle")
         self.edit_og_msg_entry.configure(variable=ttk.BooleanVar(value=self.cfg.get("message_settings.edit_og")))
-        self.edit_og_msg_entry.grid(row=len(self.config_entries) + 3, column=1, sticky=ttk.E, padx=(10, 10), pady=(2, 10), columnspan=3)
+        self.edit_og_msg_entry.grid(row=len(self.config_entries) + 3, column=1, sticky=E, padx=(10, 10), pady=(2, 10), columnspan=3)
         
         return self.wrapper
     

--- a/gui/components/settings/rich_presence.py
+++ b/gui/components/settings/rich_presence.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.helpers.style import get_current_theme_str
 import utils.console as console
 from gui.components import SettingsPanel, RoundedButton, RoundedFrame
@@ -99,14 +100,14 @@ class RichPresencePanel(SettingsPanel):
 
             if details:
                 self.details_label.configure(text=details)
-                self.details_label.grid(row=row, column=0, sticky=ttk.W)
+                self.details_label.grid(row=row, column=0, sticky=W)
                 row += 1
             else:
                 self.details_label.grid_remove()
 
             if state:
                 self.state_label.configure(text=state)
-                self.state_label.grid(row=row, column=0, sticky=ttk.W)
+                self.state_label.grid(row=row, column=0, sticky=W)
                 row += 1
             else:
                 self.state_label.grid_remove()
@@ -122,11 +123,11 @@ class RichPresencePanel(SettingsPanel):
         
     def _draw_preview(self, parent):
         wrapper = RoundedFrame(parent, radius=15, background=self.root.style.colors.get("secondary"))
-        wrapper.pack(fill=ttk.X, expand=False, pady=(10, 0), padx=10)
+        wrapper.pack(fill=X, expand=False, pady=(10, 0), padx=10)
         
         playing_label = ttk.Label(wrapper, text="Playing", font=("Host Grotesk", 10 if sys.platform != "darwin" else 12))
         playing_label.configure(background=self.root.style.colors.get("secondary"))
-        playing_label.grid(row=0, column=0, sticky=ttk.W, padx=(5, 5), pady=(5, 0))
+        playing_label.grid(row=0, column=0, sticky=W, padx=(5, 5), pady=(5, 0))
         
         large_image = self.images.load_image_from_url(self.rpc.large_image if self.rpc.large_image else "https://www.ghostt.cc/assets/ghost.png", (64, 64), 5)
         self.large_image_label = ttk.Label(wrapper, image=large_image, background=self.root.style.colors.get("secondary"))
@@ -140,33 +141,33 @@ class RichPresencePanel(SettingsPanel):
         # self.small_image_label.lift() 
         
         details_wrapper = RoundedFrame(wrapper, radius=0, background=self.root.style.colors.get("secondary"))
-        details_wrapper.grid(row=1, column=1, sticky=ttk.W, padx=(0, 5), pady=5)
+        details_wrapper.grid(row=1, column=1, sticky=W, padx=(0, 5), pady=5)
         
         self.name_label = ttk.Label(details_wrapper, text=self.rpc.name or "Ghost", font=("Host Grotesk", 14, "bold"))
         self.name_label.configure(background=self.root.style.colors.get("secondary"))
-        self.name_label.grid(row=0, column=0, sticky=ttk.W)
+        self.name_label.grid(row=0, column=0, sticky=W)
         
         self.details_label = ttk.Label(details_wrapper, text=self.rpc.details or "", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.details_label.configure(background=self.root.style.colors.get("secondary"))
-        self.details_label.grid(row=1, column=0, sticky=ttk.W)
+        self.details_label.grid(row=1, column=0, sticky=W)
         
         self.state_label = ttk.Label(details_wrapper, text=self.rpc.state or "", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.state_label.configure(background=self.root.style.colors.get("secondary"))
-        self.state_label.grid(row=2, column=0, sticky=ttk.W)
+        self.state_label.grid(row=2, column=0, sticky=W)
         
         time_elapsed_label = ttk.Label(details_wrapper, text="00:15", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         time_elapsed_label.configure(foreground="#68ae7c", background=self.root.style.colors.get("secondary"))
-        time_elapsed_label.grid(row=3, column=0, sticky=ttk.W)
+        time_elapsed_label.grid(row=3, column=0, sticky=W)
         
     def _draw_user_wrapper(self, parent):
         wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame", custom_size=True)
         wrapper.set_width(225)
-        wrapper.grid(row=1, column=1, sticky=ttk.NSEW, padx=(10, 0))
+        wrapper.grid(row=1, column=1, sticky=NSEW, padx=(10, 0))
         
         if self.user_avatar:
             accent_colour_banner = RoundedFrame(wrapper, radius=(15, 15, 0, 0), background=self.user_banner_colour, parent_background=self.root.style.colors.get("bg"))
             accent_colour_banner.set_height(85)
-            accent_colour_banner.pack(side=ttk.TOP, fill=ttk.X)
+            accent_colour_banner.pack(side=TOP, fill=X)
             accent_colour_banner.columnconfigure(0, weight=1)
             
             avatar_label = ttk.Canvas(wrapper, width=100, height=200, background=self.user_banner_colour, highlightthickness=0)
@@ -182,7 +183,7 @@ class RichPresencePanel(SettingsPanel):
             
         if self.user:
             user_info_wrapper = ttk.Frame(wrapper, style="dark.TFrame")
-            user_info_wrapper.pack(side=ttk.TOP, fill=ttk.X, pady=(35, 0), padx=(10, 10))
+            user_info_wrapper.pack(side=TOP, fill=X, pady=(35, 0), padx=(10, 10))
             user_info_wrapper.configure(height=50)
             
             display_name = ttk.Label(user_info_wrapper, text=self.user.display_name, font=("Host Grotesk", 16 if sys.platform != "darwin" else 18, "bold"))
@@ -204,11 +205,11 @@ class RichPresencePanel(SettingsPanel):
         
         toggle_label = ttk.Label(toggle_wrapper, text="Enable Rich Presence")
         toggle_label.configure(background=self.root.style.colors.get("dark"))
-        toggle_label.grid(row=0, column=0, sticky=ttk.W, padx=(10, 0), pady=10)
+        toggle_label.grid(row=0, column=0, sticky=W, padx=(10, 0), pady=10)
         toggle_label.bind("<Button-1>", lambda e: self.toggle_checkbox.invoke())
         
         self.toggle_checkbox = ttk.Checkbutton(toggle_wrapper, text="", style="success-round-toggle")
-        self.toggle_checkbox.grid(row=0, column=1, sticky=ttk.E, padx=(0, 10), pady=10)
+        self.toggle_checkbox.grid(row=0, column=1, sticky=E, padx=(0, 10), pady=10)
         self.toggle_checkbox.configure(command=self._save_rpc)
         
         toggle_wrapper.grid_columnconfigure(0, weight=1)
@@ -253,7 +254,7 @@ class RichPresencePanel(SettingsPanel):
             label = ttk.Label(self.body, text=value)
             label.configure(background=self.root.style.colors.get("dark"))
             
-            label.grid(row=index + 1, column=0, sticky=ttk.W, padx=padding[0], pady=(padding[1] + 8 if index == 1 else padding[1], padding[1]))
+            label.grid(row=index + 1, column=0, sticky=W, padx=padding[0], pady=(padding[1] + 8 if index == 1 else padding[1], padding[1]))
             entry.grid(row=index + 1, column=1, sticky="we", padx=padding[0], pady=(padding[1] + 8 if index == 1 else padding[1], padding[1]), columnspan=3)
             
             self.body.grid_columnconfigure(1, weight=1)
@@ -261,14 +262,14 @@ class RichPresencePanel(SettingsPanel):
             
         save_label = ttk.Label(self.body, text="A restart is required to apply changes!", font=("Host Grotesk", 12, "italic"))
         save_label.configure(background=self.root.style.colors.get("dark"), foreground=Style.LIGHT_GREY.value)
-        save_label.grid(row=len(self.rpc_entries) + 1, column=0, columnspan=2, sticky=ttk.W, padx=(10, 0), pady=10)
+        save_label.grid(row=len(self.rpc_entries) + 1, column=0, columnspan=2, sticky=W, padx=(10, 0), pady=10)
         
         # save_rpc_button = ttk.Button(self.body, text="Save", style="success.TButton", command=self._save_rpc)
-        # save_rpc_button.grid(row=len(self.rpc_entries) + 1, column=2, sticky=ttk.E, pady=10)
+        # save_rpc_button.grid(row=len(self.rpc_entries) + 1, column=2, sticky=E, pady=10)
         
         # reset_rpc_button = ttk.Button(self.body, text="Reset", style="danger.TButton", command=self._reset_rpc)
         reset_rpc_button = RoundedButton(self.body, text="Reset", style="danger.TButton", command=self._reset_rpc, foreground="#ffffff")
-        reset_rpc_button.grid(row=len(self.rpc_entries) + 1, column=3, sticky=ttk.E, padx=(5, 11), pady=10)
+        reset_rpc_button.grid(row=len(self.rpc_entries) + 1, column=3, sticky=E, padx=(5, 11), pady=10)
         
         self._update_preview()
         return self.wrapper

--- a/gui/components/settings/session_spoofing.py
+++ b/gui/components/settings/session_spoofing.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import utils.console as console
 from gui.components import SettingsPanel, RoundedFrame, DropdownMenu
 
@@ -33,12 +34,12 @@ class SessionSpoofingPanel(SettingsPanel):
     def draw(self):
         toggle_label = ttk.Label(self.body, text="Enable Session Spoofing")
         toggle_label.configure(background=self.root.style.colors.get("dark"))
-        toggle_label.grid(row=0, column=0, sticky=ttk.W, padx=(10, 0), pady=(15, 5))
+        toggle_label.grid(row=0, column=0, sticky=W, padx=(10, 0), pady=(15, 5))
         toggle_label.bind("<Button-1>", lambda e: self.checkbox.invoke())
         
         self.checkbox = ttk.Checkbutton(self.body, text="", style="success-round-toggle")
-        # self.checkbox.grid(row=0, column=0, columnspan=2, sticky=ttk.W, padx=(13, 0), pady=(15, 0))
-        self.checkbox.grid(row=0, column=1, sticky=ttk.E, padx=(0, 10), pady=(10, 5))
+        # self.checkbox.grid(row=0, column=0, columnspan=2, sticky=W, padx=(13, 0), pady=(15, 0))
+        self.checkbox.grid(row=0, column=1, sticky=E, padx=(0, 10), pady=(10, 5))
         self.checkbox.configure(command=self._save_session_spoofing)
         
         self.body.grid_columnconfigure(0, weight=1)
@@ -50,7 +51,7 @@ class SessionSpoofingPanel(SettingsPanel):
                 
         device_label = ttk.Label(self.body, text="Session spoofing device")
         device_label.configure(background=self.root.style.colors.get("dark"))
-        device_label.grid(row=1, column=0, sticky=ttk.NW, padx=(10, 0), pady=(10, 10))
+        device_label.grid(row=1, column=0, sticky=NW, padx=(10, 0), pady=(10, 10))
         
         # device_select_menu = ttk.Menubutton(self.body, textvariable=self.selected_device, bootstyle="secondary")
         # device_select_menu.menu = ttk.Menu(device_select_menu, tearoff=0)
@@ -64,11 +65,11 @@ class SessionSpoofingPanel(SettingsPanel):
         device_select_menu.draw().grid(row=1, column=1, sticky="we", padx=(10, 10), pady=(5, 10))
         
         # save_button = ttk.Button(self.body, text="Save", style="success.TButton", command=self._save_session_spoofing)
-        # save_button.grid(row=2, column=1, sticky=ttk.E, padx=(0, 11), pady=10)
+        # save_button.grid(row=2, column=1, sticky=E, padx=(0, 11), pady=10)
         
         # restart_required_label = ttk.Label(self.body, text="A restart is required to apply changes!", font=("Host Grotesk", 12, "italic"))
         # restart_required_label.configure(background=self.root.style.colors.get("dark"), foreground="#cccccc")
-        # restart_required_label.grid(row=2, column=0, sticky=ttk.W, padx=(10, 0), pady=10)
+        # restart_required_label.grid(row=2, column=0, sticky=W, padx=(10, 0), pady=10)
 
         self.body.grid_columnconfigure(1, weight=1)
         

--- a/gui/components/settings/snipers.py
+++ b/gui/components/settings/snipers.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import utils.console as console
 from gui.components import SettingsPanel, RoundedFrame
 
@@ -31,11 +32,11 @@ class SnipersPanel(SettingsPanel):
         self.snipers_tk_entries[sniper.name] = {}
 
         header = ttk.Frame(card, style="dark.TFrame")
-        header.grid(row=0, column=0, sticky=ttk.NSEW, pady=(10, 10), padx=10)
+        header.grid(row=0, column=0, sticky=NSEW, pady=(10, 10), padx=10)
 
         title = ttk.Label(header, text=sniper.name.capitalize() + " Sniper", font=("Host Grotesk", 18, "bold"))
         title.configure(background=self.root.style.colors.get("dark"))
-        title.grid(row=0, column=0, sticky=ttk.NSEW)
+        title.grid(row=0, column=0, sticky=NSEW)
 
         entries = [
             {
@@ -61,11 +62,11 @@ class SnipersPanel(SettingsPanel):
         for i, entry in enumerate(entries):
             if entry["type"] == "checkbox":
                 checkbox_wrapper = RoundedFrame(card, radius=8, bootstyle="secondary.TFrame")
-                checkbox_wrapper.grid(row=i + 1, column=0, sticky=ttk.NSEW, padx=10, pady=(0, 5))
+                checkbox_wrapper.grid(row=i + 1, column=0, sticky=NSEW, padx=10, pady=(0, 5))
 
                 label = ttk.Label(checkbox_wrapper, text=" " + entry["label"])
                 label.configure(background=self.root.style.colors.get("secondary"))
-                label.grid(row=0, column=0, sticky=ttk.W, pady=10, padx=(8, 0))
+                label.grid(row=0, column=0, sticky=W, pady=10, padx=(8, 0))
 
                 var = ttk.BooleanVar(value=entry["value"])
                 
@@ -76,7 +77,7 @@ class SnipersPanel(SettingsPanel):
                     command=lambda sniper_name=sniper.name: self._save_sniper(sniper_name),
                     tristatevalue=None
                 )
-                checkbox.grid(row=0, column=1, sticky=ttk.E, pady=10, padx=(0, 10))
+                checkbox.grid(row=0, column=1, sticky=E, pady=10, padx=(0, 10))
                 checkbox_wrapper.grid_columnconfigure(0, weight=1)
 
                 self.snipers_tk_entries[sniper.name][entry["config_key"]] = var
@@ -90,27 +91,27 @@ class SnipersPanel(SettingsPanel):
                 
             else:
                 wrapper = RoundedFrame(card, radius=8, bootstyle="dark.TFrame")
-                wrapper.grid(row=i + 1, column=0, sticky=ttk.NSEW, padx=10, pady=(10, 10))
+                wrapper.grid(row=i + 1, column=0, sticky=NSEW, padx=10, pady=(10, 10))
 
                 label = ttk.Label(wrapper, text=entry["label"])
                 label.configure(background=self.root.style.colors.get("dark"))
-                label.grid(row=0, column=0, sticky=ttk.W, pady=(0, 5))
+                label.grid(row=0, column=0, sticky=W, pady=(0, 5))
 
                 textbox = ttk.Entry(wrapper, font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
-                textbox.grid(row=1, column=0, sticky=ttk.EW)
+                textbox.grid(row=1, column=0, sticky=EW)
                 wrapper.grid_columnconfigure(0, weight=1)
 
                 placeholder_color = "#6c757d"  # subtle grey
                 normal_color = self.root.style.colors.get("fg")
 
                 def set_placeholder(entry_widget):
-                    entry_widget.delete(0, ttk.END)
+                    entry_widget.delete(0, END)
                     entry_widget.insert(0, self.placeholder)
                     entry_widget.configure(foreground=placeholder_color)
 
                 def clear_placeholder(entry_widget):
                     if entry_widget.get() == self.placeholder:
-                        entry_widget.delete(0, ttk.END)
+                        entry_widget.delete(0, END)
                         entry_widget.configure(foreground=normal_color)
 
                 def on_focus_in(event, entry_widget=textbox):
@@ -151,7 +152,7 @@ class SnipersPanel(SettingsPanel):
         
         for sniper in self.snipers:
             card = self._draw_card(sniper)
-            card.grid(row=row, column=0, sticky=ttk.NSEW, padx=0, pady=(0, 10))
+            card.grid(row=row, column=0, sticky=NSEW, padx=0, pady=(0, 10))
             
             row += 1
         

--- a/gui/components/settings/theming.py
+++ b/gui/components/settings/theming.py
@@ -1,5 +1,7 @@
 import sys
+import tkinter.font as tkfont
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import utils.console as console
 from utils.files import open_path_in_explorer, get_themes_path
 from gui.components import SettingsPanel, RoundedButton, RoundedFrame, DropdownMenu
@@ -70,7 +72,7 @@ class ThemingPanel(SettingsPanel):
         
         open_folder_button = ttk.Label(wrapper, image=self.images.get("folder-open"), style="secondary")
         open_folder_button.configure(background=self.root.style.colors.get("secondary"))
-        open_folder_button.pack(side=ttk.LEFT, padx=10, pady=7)
+        open_folder_button.pack(side=LEFT, padx=10, pady=7)
         open_folder_button.bind("<Button-1>", lambda e: open_path_in_explorer(get_themes_path()))
         open_folder_button.bind("<Enter>", _hover_enter)
         open_folder_button.bind("<Leave>", _hover_leave)
@@ -108,7 +110,7 @@ class ThemingPanel(SettingsPanel):
         canvas = self.preview_canvas
         canvas.delete("all")
 
-        font = ttk.font.Font(family="Host Grotesk", size=12)
+        font = tkfont.Font(family="Host Grotesk", size=12)
 
         if self.user_avatar:
             canvas.create_image(25, 25, image=self.user_avatar, anchor="center")
@@ -124,7 +126,7 @@ class ThemingPanel(SettingsPanel):
         current_row = 0
 
         colour_strip = RoundedFrame(embed_wrapper, radius=(8, 0, 0, 8), width=5, background=self.cfg.theme.colour or "#5865F2")
-        colour_strip.grid(row=0, column=0, sticky=ttk.NS, rowspan=3)
+        colour_strip.grid(row=0, column=0, sticky=NS, rowspan=3)
 
         title_text = self.cfg.theme.title or ""
         emoji_text = self.cfg.theme.emoji or ""
@@ -132,7 +134,7 @@ class ThemingPanel(SettingsPanel):
         if title_text:
             title = ttk.Label(embed_wrapper, text=f"{emoji_text} {title_text}".strip(), font=("Host Grotesk", 14, "bold"))
             title.configure(background=self.root.style.colors.get("secondary"), foreground=self.root.style.colors.get("fg"))
-            title.grid(row=current_row, column=1, sticky=ttk.NW, padx=10, pady=(8, 5))
+            title.grid(row=current_row, column=1, sticky=NW, padx=10, pady=(8, 5))
             current_row += 1
 
         description = ttk.Label(embed_wrapper, text=""".abuse ~ Abusive commands
@@ -149,7 +151,7 @@ class ThemingPanel(SettingsPanel):
 
 There are 166 commands!""", font=("Host Grotesk", 12))
         description.configure(background=self.root.style.colors.get("secondary"), foreground=self.root.style.colors.get("fg"))
-        description.grid(row=current_row, column=1, sticky=ttk.NW, padx=10, pady=(0 if title_text else 8, 10))
+        description.grid(row=current_row, column=1, sticky=NW, padx=10, pady=(0 if title_text else 8, 10))
         current_row += 1
 
         footer_text = getattr(self.cfg.theme, "footer", "") or ""
@@ -157,24 +159,24 @@ There are 166 commands!""", font=("Host Grotesk", 12))
         if footer_text:
             footer_label = ttk.Label(embed_wrapper, text=footer_text, font=("Host Grotesk", 12))
             footer_label.configure(background=self.root.style.colors.get("secondary"), foreground=Style.LIGHT_GREY.value)
-            footer_label.grid(row=current_row, column=1, sticky=ttk.W, padx=10, pady=(0, 10))
+            footer_label.grid(row=current_row, column=1, sticky=W, padx=10, pady=(0, 10))
             current_row += 1
             
         if self.embed_image:
             embed_image_label = ttk.Label(embed_wrapper, image=self.embed_image)
             embed_image_label.configure(background=self.root.style.colors.get("secondary"))
-            embed_image_label.grid(row=0, column=2, rowspan=current_row, sticky=ttk.NE, padx=10, pady=10)
+            embed_image_label.grid(row=0, column=2, rowspan=current_row, sticky=NE, padx=10, pady=10)
             
     def draw_preview(self, parent):
         wrapper = RoundedFrame(parent, radius=10,
                             background=self.root.style.colors.get("dark"))
-        wrapper.grid(row=0, column=1, sticky=ttk.NS, padx=(10, 0))
+        wrapper.grid(row=0, column=1, sticky=NS, padx=(10, 0))
         wrapper.grid_propagate(True)
 
         self.preview_canvas = ttk.Canvas(wrapper, highlightthickness=0, width=360)
         self.preview_canvas.configure(
             background=self.root.style.colors.get("dark"))
-        self.preview_canvas.pack(fill=ttk.BOTH, expand=True, padx=10, pady=10)
+        self.preview_canvas.pack(fill=BOTH, expand=True, padx=10, pady=10)
 
         self._draw_preview_contents()
         
@@ -182,7 +184,7 @@ There are 166 commands!""", font=("Host Grotesk", 12))
         self.body.grid_remove()
         
         wrapper = RoundedFrame(self.wrapper, radius=10, background=self.root.style.colors.get("dark"))
-        wrapper.grid(row=0, column=0, sticky=ttk.NSEW)
+        wrapper.grid(row=0, column=0, sticky=NSEW)
         wrapper.grid_columnconfigure(0, weight=1)
         
         self.user = self.bot_controller.get_user()
@@ -210,7 +212,7 @@ There are 166 commands!""", font=("Host Grotesk", 12))
         self.create_entry.bind("<KeyRelease>", lambda e: self.toggle_create_theme_button(self.create_entry.get().strip() != ""))
         
         self.create_button = RoundedButton(wrapper, text="+", command=lambda _: self._create_theme(self.create_entry.get()), style="success.TButton", pady=2)
-        self.create_button.grid(row=1, column=1, sticky=ttk.E, padx=(0, 10), pady=(10, 0))
+        self.create_button.grid(row=1, column=1, sticky=E, padx=(0, 10), pady=(10, 0))
         self.create_button.set_state("disabled")
         
         #-------
@@ -244,7 +246,7 @@ There are 166 commands!""", font=("Host Grotesk", 12))
             )
             label.configure(background=self.root.style.colors.get("dark"))
 
-            label.grid(row=row, column=0, sticky=ttk.W, padx=10, pady=(0, 2))
+            label.grid(row=row, column=0, sticky=W, padx=10, pady=(0, 2))
             entry.grid(row=row + 1, column=0, columnspan=2, sticky="we", padx=10, pady=(0, 10))
 
             entry.bind("<KeyRelease>", self._schedule_preview_update)
@@ -272,10 +274,10 @@ There are 166 commands!""", font=("Host Grotesk", 12))
         # open_folder_button = RoundedButton(buttons_frame, image=self.images.get("folder-open"), style="secondary.TButton", command=lambda _: open_path_in_explorer(get_themes_path()))
         open_folder_button = self._draw_open_folder_button(buttons_frame)
 
-        # save_theme_label.grid(row=0, column=0, columnspan=2, sticky=ttk.W, padx=(10, 0), pady=(0, 10))
-        save_theme_button.grid(row=0, column=1, sticky=ttk.E, pady=(0, 10))
-        delete_theme_button.grid(row=0, column=2, sticky=ttk.E, padx=5, pady=(0, 10))
-        open_folder_button.grid(row=0, column=3, sticky=ttk.E, padx=(0, 11), pady=(0, 10))
+        # save_theme_label.grid(row=0, column=0, columnspan=2, sticky=W, padx=(10, 0), pady=(0, 10))
+        save_theme_button.grid(row=0, column=1, sticky=E, pady=(0, 10))
+        delete_theme_button.grid(row=0, column=2, sticky=E, padx=5, pady=(0, 10))
+        open_folder_button.grid(row=0, column=3, sticky=E, padx=(0, 11), pady=(0, 10))
         
         self.draw_preview(self.wrapper)
         

--- a/gui/components/settings_frame.py
+++ b/gui/components/settings_frame.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components import RoundedFrame
 from utils.config import Config
 
@@ -28,7 +29,7 @@ class SettingsFrame:
             self.body.pack_forget()
         else:
             self.header.set_corner_radius((15, 15, 0, 0))
-            self.body.pack(fill=ttk.BOTH, expand=False)
+            self.body.pack(fill=BOTH, expand=False)
         
     def _hover_enter(self, _):
         self.header.set_background(background=self.hover_colour)
@@ -42,15 +43,15 @@ class SettingsFrame:
         
     def _draw_header(self, parent):
         self.header = RoundedFrame(parent, radius=(15, 15, 0, 0), bootstyle="secondary.TFrame")
-        self.header.pack(fill=ttk.BOTH, expand=False)
+        self.header.pack(fill=BOTH, expand=False)
         
         self.title = ttk.Label(self.header, text=self.header_text, font=("Host Grotesk", 14 if sys.platform != "darwin" else 18, "bold"))
         self.title.configure(background=self.root.style.colors.get("secondary"))
-        self.title.grid(row=0, column=0, sticky=ttk.NSEW, padx=15, pady=10)
+        self.title.grid(row=0, column=0, sticky=NSEW, padx=15, pady=10)
         
         self.icon = ttk.Label(self.header, image=self.header_icon)
         self.icon.configure(background=self.root.style.colors.get("secondary"))
-        self.icon.grid(row=0, column=2, sticky=ttk.E, padx=(0, 15), pady=10)
+        self.icon.grid(row=0, column=2, sticky=E, padx=(0, 15), pady=10)
         
         self.header.grid_columnconfigure(1, weight=1)
         
@@ -62,7 +63,7 @@ class SettingsFrame:
         
     def _draw_body(self, parent):
         frame = RoundedFrame(parent, radius=15, bootstyle="dark.TFrame")
-        # frame.pack(fill=ttk.BOTH, expand=False)
+        # frame.pack(fill=BOTH, expand=False)
         frame.grid(column=0, row=1, sticky="nsew")
         parent.grid_columnconfigure(0, weight=1)
         
@@ -74,7 +75,7 @@ class SettingsFrame:
         else:
             wrapper = ttk.Frame(self.parent, takefocus=True)
         wrapper.configure(style="default.TLabel")
-        # wrapper.pack(fill=ttk.BOTH, expand=True)
+        # wrapper.pack(fill=BOTH, expand=True)
         # wrapper.grid(column=0, row=0, sticky="nsew")
         
         # self._draw_header(wrapper)

--- a/gui/components/sidebar.py
+++ b/gui/components/sidebar.py
@@ -1,5 +1,6 @@
 import os, sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from ttkbootstrap.dialogs import Messagebox
 from gui.helpers import Images
 from gui.components import RoundedFrame, RoundedButton
@@ -47,7 +48,7 @@ class Sidebar:
             background=bg_color
         )
         
-        button_wrapper.grid(row=row, column=0, sticky=ttk.NSEW, pady=(10 if sys.platform == "darwin" or sys.platform == "win32" else 25, 2) if row == 0 else 2, ipady=8, padx=10)
+        button_wrapper.grid(row=row, column=0, sticky=NSEW, pady=(10 if sys.platform == "darwin" or sys.platform == "win32" else 25, 2) if row == 0 else 2, ipady=8, padx=10)
         
         button = ttk.Label(button_wrapper, image=image, anchor="center", background=bg_color)
         
@@ -59,8 +60,8 @@ class Sidebar:
         button.bind("<Enter>", lambda e: self._hover_enter(button_wrapper, button, page_name))
         button.bind("<Leave>", lambda e: self._hover_leave(button_wrapper, button, page_name))
         
-        # button.grid(row=row, column=0, sticky=ttk.NSEW, pady=(10, 2) if row == 0 else 2, ipady=12)
-        button.pack(fill=ttk.BOTH, expand=True, padx=5, pady=5)
+        # button.grid(row=row, column=0, sticky=NSEW, pady=(10, 2) if row == 0 else 2, ipady=12)
+        button.pack(fill=BOTH, expand=True, padx=5, pady=5)
         
         self.tk_buttons.append(button)
         
@@ -94,7 +95,7 @@ class Sidebar:
         self.sidebar = RoundedFrame(self.root, radius=(0, 0, 0, 25), background=Style.WINDOW_BORDER.value)
         self.sidebar.set_height(self.root.winfo_height())
         self.sidebar.set_width(self.width + 7)
-        # self.sidebar.pack(side=ttk.LEFT, fill=ttk.BOTH)
+        # self.sidebar.pack(side=LEFT, fill=BOTH)
         self.sidebar.grid_propagate(False)
     
         self.buttons = {
@@ -109,7 +110,7 @@ class Sidebar:
         logout_btn.bind("<Button-1>", lambda e: self._quit())
         logout_btn.bind("<Enter>", lambda e: self._hover_enter(logout_btn, "logout"))
         logout_btn.bind("<Leave>", lambda e: self._hover_leave(logout_btn, "logout"))
-        # logout_btn.grid(row=len(self.buttons) + 2, column=0, sticky=ttk.NSEW, pady=10, ipady=12)
+        # logout_btn.grid(row=len(self.buttons) + 2, column=0, sticky=NSEW, pady=10, ipady=12)
         
         self.sidebar.grid_rowconfigure(len(self.buttons) + 1, weight=1)
         self.sidebar.grid_columnconfigure(0, weight=1)

--- a/gui/components/titlebar.py
+++ b/gui/components/titlebar.py
@@ -5,6 +5,7 @@ if sys.platform == "win32":
     import hPyT
 
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components import RoundedFrame
 from gui.helpers.style import Style, get_current_theme_str
 
@@ -105,21 +106,21 @@ class Titlebar:
 
             close_btn = ttk.Label(inner_wrapper, text="●", foreground="#FF5F57", font=("Arial", 25))
             close_btn.configure(background=Style.WINDOW_BORDER.value)
-            close_btn.pack(side=ttk.LEFT, padx=(0, 0))
+            close_btn.pack(side=LEFT, padx=(0, 0))
             close_btn.bind("<Button-1>", lambda e: self._close())
             close_btn.bind("<Enter>", lambda e: close_btn.configure(foreground="#CC4940"))
             close_btn.bind("<Leave>", lambda e: close_btn.configure(foreground="#FF5F57"))
             
             minimize_btn = ttk.Label(inner_wrapper, text="●", foreground=Style.MAC_TITLEBAR_INACTIVE.value, font=("Arial", 28 if get_current_theme_str() == "dark" else 25))
             minimize_btn.configure(background=Style.WINDOW_BORDER.value)
-            minimize_btn.pack(side=ttk.LEFT, padx=(0, 0))
+            minimize_btn.pack(side=LEFT, padx=(0, 0))
             # minimize_btn.bind("<Button-1>", lambda e: self._minimize())
             # minimize_btn.bind("<Enter>", lambda e: minimize_btn.configure(foreground="#CC9A26"))
             # minimize_btn.bind("<Leave>", lambda e: minimize_btn.configure(foreground="#FFBD2E"))
             
             maximize_btn = ttk.Label(inner_wrapper, text="●", foreground=Style.MAC_TITLEBAR_INACTIVE.value, font=("Arial", 28 if get_current_theme_str() == "dark" else 25))
             maximize_btn.configure(background=Style.WINDOW_BORDER.value)
-            maximize_btn.pack(side=ttk.LEFT, padx=(0, 5))
+            maximize_btn.pack(side=LEFT, padx=(0, 5))
             # maximize_btn.bind("<Enter>", lambda e: maximize_btn.configure(foreground="#20A833"))
             # maximize_btn.bind("<Leave>", lambda e: maximize_btn.configure(foreground="#28C940"))
             # maximize_btn.bind("<Button-1>", lambda e: self._maximize())
@@ -127,11 +128,11 @@ class Titlebar:
         else:
             ico = ttk.Label(inner_wrapper, image=self.images.images["titlebar-ico"])
             ico.configure(background=Style.WINDOW_BORDER.value)
-            ico.pack(side=ttk.LEFT, padx=(5, 0))
+            ico.pack(side=LEFT, padx=(5, 0))
 
             title = ttk.Label(inner_wrapper, text="Ghost", font=("Host Grotesk", 12))
             title.configure(background=Style.WINDOW_BORDER.value)
-            title.pack(side=ttk.LEFT, padx=(5, 0))
+            title.pack(side=LEFT, padx=(5, 0))
             
             def close_btn_enter(e):
                 close_btn.configure(background=Style.SETTINGS_PILL_HOVER.value, foreground=self.root.style.colors.get("fg"))
@@ -142,14 +143,14 @@ class Titlebar:
                 close_btn_wrapper.set_background(Style.WINDOW_BORDER.value)
 
             close_btn_wrapper = RoundedFrame(inner_wrapper, radius=10, background=Style.WINDOW_BORDER.value)
-            close_btn_wrapper.pack(side=ttk.RIGHT)
+            close_btn_wrapper.pack(side=RIGHT)
             close_btn_wrapper.bind("<Button-1>", lambda e: self._close())
             close_btn_wrapper.bind("<Enter>", close_btn_enter)
             close_btn_wrapper.bind("<Leave>", close_btn_leave)
 
             close_btn = ttk.Label(close_btn_wrapper, text="⨉", font=("Arial", 13))
             close_btn.configure(background=Style.WINDOW_BORDER.value, foreground=self.root.style.colors.get("fg"))
-            close_btn.pack(fill=ttk.BOTH, expand=True, padx=8, pady=4)
+            close_btn.pack(fill=BOTH, expand=True, padx=8, pady=4)
             close_btn.bind("<Button-1>", lambda e: self.root.quit())
             close_btn.bind("<Enter>", close_btn_enter)
             close_btn.bind("<Leave>", close_btn_leave)
@@ -163,17 +164,17 @@ class Titlebar:
                 minimize_btn_wrapper.set_background(Style.WINDOW_BORDER.value)
 
             minimize_btn_wrapper = RoundedFrame(inner_wrapper, radius=10, background=Style.WINDOW_BORDER.value)
-            minimize_btn_wrapper.pack(side=ttk.RIGHT)
+            minimize_btn_wrapper.pack(side=RIGHT)
             minimize_btn_wrapper.bind("<Button-1>", lambda e: self._minimize())
             minimize_btn_wrapper.bind("<Enter>", minimize_btn_enter)
             minimize_btn_wrapper.bind("<Leave>", minimize_btn_leave)
 
             minimize_btn = ttk.Label(minimize_btn_wrapper, text="—", font=("Arial", 10))
             minimize_btn.configure(background=Style.WINDOW_BORDER.value, foreground=self.root.style.colors.get("fg"))
-            minimize_btn.pack(fill=ttk.BOTH, expand=True, padx=8, pady=5)
+            minimize_btn.pack(fill=BOTH, expand=True, padx=8, pady=5)
             minimize_btn.bind("<Button-1>", lambda e: self._minimize())
             minimize_btn.bind("<Enter>", minimize_btn_enter)
             minimize_btn.bind("<Leave>", minimize_btn_leave)
 
-        inner_wrapper.pack(fill=ttk.BOTH, expand=True, pady=pady, padx=padx)
+        inner_wrapper.pack(fill=BOTH, expand=True, pady=pady, padx=padx)
         return titlebar

--- a/gui/components/tool_page.py
+++ b/gui/components/tool_page.py
@@ -1,6 +1,7 @@
 import abc
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components import RoundedFrame
 from gui.helpers.style import Style
 
@@ -25,15 +26,15 @@ class ToolPage:
         wrapper = ttk.Frame(parent)
 
         tools_label = ttk.Label(wrapper, text="Tools", font=("Host Grotesk", 24, "bold"), foreground=Style.LIGHT_GREY.value)
-        tools_label.grid(row=0, column=0, sticky=ttk.W)
+        tools_label.grid(row=0, column=0, sticky=W)
         tools_label.bind("<Button-1>", lambda e: self.go_back())
 
         back_button = ttk.Label(wrapper, image=self.images.get("right-chevron-small"))
         back_button.bind("<Button-1>", lambda e: self.go_back())
-        back_button.grid(row=0, column=1, sticky=ttk.W, padx=(10, 10))
+        back_button.grid(row=0, column=1, sticky=W, padx=(10, 10))
 
         page_name = ttk.Label(wrapper, text=self.title, font=("Host Grotesk", 24, "bold"))
-        page_name.grid(row=0, column=2, sticky=ttk.W)
+        page_name.grid(row=0, column=2, sticky=W)
         page_name.bind("<Button-1>", lambda e: self.go_back())
 
         return wrapper
@@ -41,14 +42,14 @@ class ToolPage:
     def draw(self, parent):
         # Draw shared navigation
         navigation = self.draw_navigation(parent)
-        navigation.pack(side=ttk.TOP, fill=ttk.X, pady=(0, 10))
+        navigation.pack(side=TOP, fill=X, pady=(0, 10))
 
         # Create shared content wrapper
         if self.frame:
             wrapper = RoundedFrame(parent, radius=10, style="dark.TFrame")
         else:
             wrapper = ttk.Frame(parent)
-        wrapper.pack(side=ttk.TOP, fill=ttk.BOTH, expand=True, pady=(10, 0))
+        wrapper.pack(side=TOP, fill=BOTH, expand=True, pady=(10, 0))
 
         # Call subclass-specific content render
         self.draw_content(wrapper)

--- a/gui/components/tools/message_log_entry.py
+++ b/gui/components/tools/message_log_entry.py
@@ -2,6 +2,7 @@ import sys
 import time
 import math
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import discord
 
 from gui.components import RoundedFrame
@@ -49,15 +50,15 @@ class MessageLogEntry:
                 bootstyle="secondary.TFrame",
                 parent_background=self.root.style.colors.get("dark")
             )
-            self.frame.pack(fill=ttk.X, pady=(0, 8), padx=(0, 8), expand=True)
+            self.frame.pack(fill=X, pady=(0, 8), padx=(0, 8), expand=True)
 
             # Inner content
             content_frame = ttk.Frame(self.frame, style="secondary.TFrame")
-            content_frame.pack(fill=ttk.BOTH, expand=True, padx=(12, 20), pady=10)
+            content_frame.pack(fill=BOTH, expand=True, padx=(12, 20), pady=10)
 
             # Author line
             author_frame = ttk.Frame(content_frame, style="secondary.TFrame")
-            author_frame.pack(fill=ttk.X, pady=(0, 8))
+            author_frame.pack(fill=X, pady=(0, 8))
 
             # Avatar
             if self.author.avatar:
@@ -72,7 +73,7 @@ class MessageLogEntry:
                 if self.avatars[self.author.id]:
                     avatar_label = ttk.Label(author_frame, image=self.avatars[self.author.id])
                     avatar_label.configure(background=self.root.style.colors.get("secondary"))
-                    avatar_label.pack(side=ttk.LEFT, padx=(0, 5))
+                    avatar_label.pack(side=LEFT, padx=(0, 5))
 
             # Author name
             author_label = ttk.Label(
@@ -81,7 +82,7 @@ class MessageLogEntry:
                 font=("Host Grotesk", 12 if sys.platform != "darwin" else 14, "bold")
             )
             author_label.configure(background=self.root.style.colors.get("secondary"), foreground="white")
-            author_label.pack(side=ttk.LEFT)
+            author_label.pack(side=LEFT)
 
             # Time
             formatted_time = time.strftime("%H:%M:%S", time.localtime(self.delete_time))
@@ -91,7 +92,7 @@ class MessageLogEntry:
                 font=("Host Grotesk", 8 if sys.platform != "darwin" else 10)
             )
             time_label.configure(background=self.root.style.colors.get("secondary"), foreground=Style.LIGHT_GREY.value)
-            time_label.pack(side=ttk.LEFT, padx=(5, 0), pady=(2, 0))
+            time_label.pack(side=LEFT, padx=(5, 0), pady=(2, 0))
 
             # Channel info
             channel_label_text = (
@@ -105,7 +106,7 @@ class MessageLogEntry:
                 font=("Host Grotesk", 8 if sys.platform != "darwin" else 10, "italic")
             )
             channel_label.configure(background=self.root.style.colors.get("secondary"), foreground=Style.LIGHT_GREY.value)
-            channel_label.pack(fill=ttk.X, pady=(0, 8))
+            channel_label.pack(fill=X, pady=(0, 8))
 
             self.content_label = ttk.Text(content_frame, font=("Host Grotesk", 10 if sys.platform != "darwin" else 12), wrap="word", state="normal")
             self.content_label.insert("1.0", self.message.content or "[No text content]")
@@ -117,7 +118,7 @@ class MessageLogEntry:
                 highlightthickness=0
             )
             
-            self.content_label.pack(fill=ttk.X)
+            self.content_label.pack(fill=X)
             
             self.root.after(100, lambda: self._autoresize_text(self.content_label))
             self.content_label.bind("<Configure>", lambda e: self._autoresize_text(self.content_label))
@@ -134,7 +135,7 @@ class MessageLogEntry:
                     font=("Host Grotesk", 9, "italic")
                 )
                 attachments_label.configure(background=self.root.style.colors.get("secondary"), foreground=Style.LIGHT_GREY.value)
-                attachments_label.pack(fill=ttk.X, pady=(4, 0))
+                attachments_label.pack(fill=X, pady=(4, 0))
 
             self.frame.bind("<Button-1>", self.on_click)
 

--- a/gui/font_check.py
+++ b/gui/font_check.py
@@ -1,5 +1,7 @@
 import os, sys
+import tkinter as tk
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 
 from gui.helpers import layout, Style
 from gui.components import RoundedFrame, RoundedButton
@@ -10,7 +12,7 @@ from utils.config import Config
 class FontCheckGUI:
     def __init__(self):
         self.cfg = Config()
-        self.root = ttk.tk.Tk()
+        self.root = tk.Tk()
         self.root.title("Ghost")
         if os.name == "nt":
             self.root.iconbitmap(resource_path("data/icon.ico"))
@@ -36,18 +38,18 @@ class FontCheckGUI:
         message = "The required fonts for Ghost have not been found! Would you like Ghost to automatically install them?"
         warning = "If you do not proceed Ghost will use the default system font which may not look as intended!"
         frame = RoundedFrame(self.root, radius=15, bootstyle="dark.TFrame")
-        frame.pack(fill=ttk.BOTH, padx=10, pady=10, expand=True)
+        frame.pack(fill=BOTH, padx=10, pady=10, expand=True)
         
         title = ttk.Label(frame, text="Missing Fonts", font="-weight bold -size 20")
         title.configure(background=self.root.style.colors.get("dark"))
-        title.pack(fill=ttk.BOTH, padx=10, pady=(10, 5))
+        title.pack(fill=BOTH, padx=10, pady=(10, 5))
         
         message_label = ttk.Label(frame, text=message, font="-size 12", wraplength=300)
         message_label.configure(background=self.root.style.colors.get("dark"))
-        message_label.pack(fill=ttk.BOTH, padx=10)
+        message_label.pack(fill=BOTH, padx=10)
         
         fonts_list_wrapper = RoundedFrame(frame, radius=10, style="secondary.TFrame")
-        fonts_list_wrapper.pack(fill=ttk.BOTH, padx=10, pady=10)
+        fonts_list_wrapper.pack(fill=BOTH, padx=10, pady=10)
 
         fonts_list_scrollable = ttk.Text(fonts_list_wrapper, wrap="word", height=8, font="-size 12", width=30)
         fonts_list_scrollable.config(
@@ -57,25 +59,25 @@ class FontCheckGUI:
             highlightcolor=self.root.style.colors.get("secondary"),
             highlightbackground=self.root.style.colors.get("secondary"),
         )
-        fonts_list_scrollable.pack(fill=ttk.BOTH, padx=5, pady=5)
+        fonts_list_scrollable.pack(fill=BOTH, padx=5, pady=5)
         
         for font in get_fonts():
-            fonts_list_scrollable.insert(ttk.END, f"{font}\n")
+            fonts_list_scrollable.insert(END, f"{font}\n")
         
         fonts_list_scrollable.config(state="disabled")
         
         warning_label = ttk.Label(frame, text=warning, font="-slant italic -size 12", wraplength=300)
         warning_label.configure(background=self.root.style.colors.get("dark"), foreground="#cccccc")
-        warning_label.pack(fill=ttk.BOTH, padx=10, pady=(0, 10))
+        warning_label.pack(fill=BOTH, padx=10, pady=(0, 10))
         
         button_wrapper = ttk.Frame(frame, style="dark.TFrame")
-        button_wrapper.pack(fill=ttk.BOTH, padx=10, pady=10)
+        button_wrapper.pack(fill=BOTH, padx=10, pady=10)
         
         install_button = RoundedButton(button_wrapper, text="Install Fonts", style="primary.TButton", command=self._install_fonts, pady=2)
-        install_button.pack(side=ttk.LEFT)
+        install_button.pack(side=LEFT)
         
         skip_button = RoundedButton(button_wrapper, text="Skip", style="danger.TButton", command=self._skip, pady=2)
-        skip_button.pack(side=ttk.LEFT, padx=(5, 0))
+        skip_button.pack(side=LEFT, padx=(5, 0))
         
     def run(self):
         layout.center_window(self.root, 450, 450)

--- a/gui/helpers/layout.py
+++ b/gui/helpers/layout.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from ttkbootstrap.scrolled import ScrolledFrame
 from gui.components import RoundedFrame
 from gui.helpers.style import Style
@@ -38,7 +39,7 @@ class Layout:
                 radius=(0, 0, 25, 0),  # ALL corners here
                 background=Style.WINDOW_BORDER.value
             )
-            border.pack(fill=ttk.BOTH, expand=True)
+            border.pack(fill=BOTH, expand=True)
 
             outer = RoundedFrame(
                 border,
@@ -46,7 +47,7 @@ class Layout:
                 background=self.root.style.colors.get("bg")
             )
             outer.pack(
-                fill=ttk.BOTH,
+                fill=BOTH,
                 expand=True,
                 padx=(0, 8),
                 pady=(0, 8)
@@ -57,7 +58,7 @@ class Layout:
                 outer,
                 style="TFrame"
             )
-            safe.pack(fill=ttk.BOTH, expand=True, padx=15, pady=15)
+            safe.pack(fill=BOTH, expand=True, padx=15, pady=15)
 
             # INNER: scrolling container (optional)
             if scrollable:
@@ -66,7 +67,7 @@ class Layout:
                     width=width,
                     height=self.height
                 )
-                inner.pack(fill=ttk.BOTH, expand=True)
+                inner.pack(fill=BOTH, expand=True)
                 content_parent = inner
             else:
                 content_parent = safe
@@ -78,7 +79,7 @@ class Layout:
                 height=self.height
             )
             main.pack(
-                fill=ttk.BOTH,
+                fill=BOTH,
                 expand=True,
                 padx=(8, 22) if scrollable else padx,
                 pady=8 if scrollable else pady
@@ -89,13 +90,13 @@ class Layout:
             
             if scrollable:
                 wrapper = ScrolledFrame(self.root, width=width, height=self.height)
-                wrapper.pack(fill=ttk.BOTH, expand=True)
+                wrapper.pack(fill=BOTH, expand=True)
                 
                 # main = ttk.Frame(wrapper)
-                # main.pack(fill=ttk.BOTH, expand=True, padx=23, pady=23)
+                # main.pack(fill=BOTH, expand=True, padx=23, pady=23)
 
             main = ttk.Frame(wrapper, width=width, height=self.height)
-            main.pack(fill=ttk.BOTH, expand=True, padx=(23, 32) if scrollable else 25, pady=23 if scrollable else 25)
+            main.pack(fill=BOTH, expand=True, padx=(23, 32) if scrollable else 25, pady=23 if scrollable else 25)
 
         return main
     
@@ -113,10 +114,10 @@ class Layout:
 
         if sys.platform == "darwin" or sys.platform == "win32":
             titlebar = self.titlebar.draw()
-            titlebar.pack(fill=ttk.X, side=ttk.TOP)
+            titlebar.pack(fill=X, side=TOP)
 
         sidebar = self.sidebar.draw()
-        sidebar.pack(side=ttk.LEFT, fill=ttk.BOTH)
+        sidebar.pack(side=LEFT, fill=BOTH)
         
     hide_titlebar  = lambda self: self.root.overrideredirect(True) if sys.platform != "linux" else None
     show_titlebar  = lambda self: self.root.overrideredirect(False) if sys.platform != "linux" else None

--- a/gui/main.py
+++ b/gui/main.py
@@ -5,6 +5,7 @@ if sys.platform == "win32":
     import hPyT
 
 os.environ["SSL_CERT_FILE"] = certifi.where()
+import tkinter as tk
 import ttkbootstrap as ttk
 
 from utils.notifier import Notifier
@@ -23,7 +24,7 @@ class GhostGUI:
         self.bot_controller = bot_controller
         self.resize_grips = {}
         
-        self.root = ttk.tk.Tk()
+        self.root = tk.Tk()
         self.root.size = self.size
         self.root.title("Ghost")
         self.root.gui_ref = self
@@ -158,7 +159,7 @@ class GhostGUI:
 
         # Ensure they stay on top
         for grip in self.resize_grips.values():
-            ttk.tk.Misc.lift(grip)
+            tk.Misc.lift(grip)
         
     def _create_resize_grips(self):
         if sys.platform != "darwin":
@@ -215,7 +216,7 @@ class GhostGUI:
             # self.resize_grips["right"].set_corner_radius((0, 25, 25, 0))
 
             for grip in self.resize_grips.values():
-                ttk.tk.Misc.lift(grip)
+                tk.Misc.lift(grip)
         except Exception as e:
             print("Error positioning grips, resetting grips")
             self.resize_grips = {}

--- a/gui/pages/home.py
+++ b/gui/pages/home.py
@@ -1,5 +1,6 @@
 import webbrowser, discord, sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import tkinter.font as tkFont
 from ttkbootstrap.scrolled import ScrolledFrame
 from gui.components import RoundedFrame, RoundedButton
@@ -78,7 +79,7 @@ class HomePage:
         restart_label = ttk.Label(frame, image=self.images.get("restart"), anchor="center")
         restart_label.configure(background=self.root.style.colors.get("primary") if not disabled else self.root.style.colors.get("disabled"))
         # restart_label.configure(background=self.root.style.colors.get("secondary"))
-        restart_label.pack(anchor="center", fill=ttk.BOTH, expand=False, padx=25, pady=10)
+        restart_label.pack(anchor="center", fill=BOTH, expand=False, padx=25, pady=10)
         
         if not disabled:
             restart_label.bind("<Button-1>", lambda e: self._restart_bot())
@@ -92,24 +93,24 @@ class HomePage:
         
     def _draw_header(self, parent):
         wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="secondary.TFrame")
-        wrapper.pack(fill=ttk.BOTH, expand=False, pady=(0, 10))
+        wrapper.pack(fill=BOTH, expand=False, pady=(0, 10))
         
         if self.avatar and not self.restart:
             avatar = ttk.Label(wrapper, image=self.avatar)
             avatar.configure(background=self.root.style.colors.get("secondary"))
-            avatar.grid(row=0, column=0, sticky=ttk.W, padx=(15, 10), pady=15, rowspan=2)
+            avatar.grid(row=0, column=0, sticky=W, padx=(15, 10), pady=15, rowspan=2)
             
         if not self.restart:
             display_name = ttk.Label(wrapper, text=self.bot_controller.get_user().display_name, font=("Host Grotesk", 24, "bold"))
             display_name.configure(background=self.root.style.colors.get("secondary"))
-            display_name.grid(row=0, column=1, sticky=ttk.W, pady=(15, 0))
+            display_name.grid(row=0, column=1, sticky=W, pady=(15, 0))
 
             username = ttk.Label(wrapper, text=self.bot_controller.get_user().name, font=("Host Grotesk", 14 if sys.platform != "darwin" else 16, "italic"))
             username.configure(background=self.root.style.colors.get("secondary"), foreground=Style.LIGHT_GREY.value)
-            username.grid(row=1, column=1, sticky=ttk.W, pady=(0, 15))
+            username.grid(row=1, column=1, sticky=W, pady=(0, 15))
             
             # restart_btn = self._draw_restart_button(wrapper)
-            # restart_btn.grid(row=0, column=3, rowspan=2, sticky=ttk.EW, padx=(10, 16), pady=(10, 10))
+            # restart_btn.grid(row=0, column=3, rowspan=2, sticky=EW, padx=(10, 16), pady=(10, 10))
             
             self.restart_image = self.images.get("restart")
             
@@ -117,20 +118,20 @@ class HomePage:
                 self.restart_image = self.images.change_image_colour("restart", "#ffffff", tk_image=True)
                 
             restart_btn = RoundedButton(wrapper, radius=8, bootstyle="primary.TButton", command=lambda _: self._restart_bot(), image=self.restart_image, padx=15, pady=6)
-            restart_btn.grid(row=0, column=3, rowspan=2, sticky=ttk.EW, padx=(10, 16), pady=(10, 10))
+            restart_btn.grid(row=0, column=3, rowspan=2, sticky=EW, padx=(10, 16), pady=(10, 10))
             
             wrapper.grid_columnconfigure(2, weight=1)
         else:
             self.restart_title = ttk.Label(wrapper, text=f"{self.restart_title_text}...", font=("Host Grotesk", 24, "bold"), anchor="center")
             self.restart_title.configure(background=self.root.style.colors.get("secondary"))
-            self.restart_title.grid(row=0, column=0, sticky=ttk.NSEW, pady=26, padx=15, columnspan=2)
+            self.restart_title.grid(row=0, column=0, sticky=NSEW, pady=26, padx=15, columnspan=2)
             wrapper.grid_columnconfigure(0, weight=1)
             self.root.after(750, self._update_restart_title)
     
     def _draw_details_wrapper(self, parent):
         wrapper = ttk.Frame(parent, width=self.width)
         wrapper.configure(style="default.TLabel")
-        wrapper.pack(fill=ttk.BOTH, expand=False, pady=(10, 0))
+        wrapper.pack(fill=BOTH, expand=False, pady=(10, 0))
         
         wrapper.grid_rowconfigure(0, weight=1)
         wrapper.grid_columnconfigure(0, weight=1)
@@ -140,69 +141,69 @@ class HomePage:
     
     def _draw_account_details(self, parent):
         wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        wrapper.grid(row=0, column=0, sticky=ttk.NSEW, padx=(0, 5), pady=(0, 5))
+        wrapper.grid(row=0, column=0, sticky=NSEW, padx=(0, 5), pady=(0, 5))
         
         if self.restart:
             return
         
         title = ttk.Label(wrapper, text="Discord", font=("Host Grotesk", 14 if sys.platform != "darwin" else 18, "bold"))
         title.configure(background=self.root.style.colors.get("dark"))
-        title.grid(row=0, column=0, sticky=ttk.W, padx=10, pady=(10, 0))
+        title.grid(row=0, column=0, sticky=W, padx=10, pady=(10, 0))
         
         ttk.Separator(wrapper, orient="horizontal").grid(row=1, column=0, columnspan=2, sticky="we", padx=(10, 10), pady=5)
         wrapper.grid_columnconfigure(1, weight=1)
         
         self.friends_label = ttk.Label(wrapper, text=f"Friends: {len(self.bot_controller.get_friends())}", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.friends_label.configure(background=self.root.style.colors.get("dark"), foreground="white" if not self.restart else Style.LIGHT_GREY.value)
-        self.friends_label.grid(row=2, column=0, sticky=ttk.W, padx=10, pady=(5, 0))
+        self.friends_label.grid(row=2, column=0, sticky=W, padx=10, pady=(5, 0))
         
         self.guilds_label = ttk.Label(wrapper, text=f"Guilds: {len(self.bot_controller.get_guilds())}", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.guilds_label.configure(background=self.root.style.colors.get("dark"), foreground="white" if not self.restart else Style.LIGHT_GREY.value)
-        self.guilds_label.grid(row=3, column=0, sticky=ttk.W, padx=10, pady=(0, 10))
+        self.guilds_label.grid(row=3, column=0, sticky=W, padx=10, pady=(0, 10))
         
     def _draw_bot_details(self, parent):
         wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        wrapper.grid(row=0, column=1, sticky=ttk.NSEW, padx=(5, 0), pady=(0, 5))
+        wrapper.grid(row=0, column=1, sticky=NSEW, padx=(5, 0), pady=(0, 5))
         
         if self.restart:
             return
         
         title = ttk.Label(wrapper, text="Ghost", font=("Host Grotesk", 14 if sys.platform != "darwin" else 18, "bold"))
         title.configure(background=self.root.style.colors.get("dark"))
-        title.grid(row=0, column=0, sticky=ttk.W, padx=10, pady=(10, 0))
+        title.grid(row=0, column=0, sticky=W, padx=10, pady=(10, 0))
         
         ttk.Separator(wrapper, orient="horizontal").grid(row=1, column=0, columnspan=2, sticky="we", padx=(10, 10), pady=5)
         wrapper.grid_columnconfigure(1, weight=1)
         
         version = ttk.Label(wrapper, text=f"Version: {VERSION}", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         version.configure(background=self.root.style.colors.get("dark"))
-        version.grid(row=2, column=0, sticky=ttk.W, padx=(10, 0), pady=(5, 0))    
+        version.grid(row=2, column=0, sticky=W, padx=(10, 0), pady=(5, 0))    
         
         self.uptime_label = ttk.Label(wrapper, text=f"Uptime: {self.bot_controller.get_uptime()}", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.uptime_label.configure(background=self.root.style.colors.get("dark"), foreground="white" if not self.restart else Style.LIGHT_GREY.value)
-        self.uptime_label.grid(row=3, column=0, sticky=ttk.W, padx=(10, 0))
+        self.uptime_label.grid(row=3, column=0, sticky=W, padx=(10, 0))
         
         self.latency_label = ttk.Label(wrapper, text=f"Latency: {self.bot_controller.get_latency()}", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.latency_label.configure(background=self.root.style.colors.get("dark"), foreground="white" if not self.restart else Style.LIGHT_GREY.value)
-        self.latency_label.grid(row=4, column=0, sticky=ttk.W, padx=(10, 0), pady=(0, 10))
+        self.latency_label.grid(row=4, column=0, sticky=W, padx=(10, 0), pady=(0, 10))
         
     def _draw_details(self, parent):
         wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        wrapper.pack(fill=ttk.BOTH, expand=False, pady=(0, 10))
+        wrapper.pack(fill=BOTH, expand=False, pady=(0, 10))
 
         font = ("Host Grotesk", 14)
         
         version = ttk.Label(wrapper, text=f"Ghost v{VERSION}", font=font)
         version.configure(background=self.root.style.colors.get("dark"))
-        version.grid(row=0, column=0, sticky=ttk.W, padx=(10, 0), pady=10)
+        version.grid(row=0, column=0, sticky=W, padx=(10, 0), pady=10)
         
         self.uptime_label = ttk.Label(wrapper, text=f"Uptime: {self.bot_controller.get_uptime()}", font=font)
         self.uptime_label.configure(background=self.root.style.colors.get("dark"))
-        self.uptime_label.grid(row=0, column=1, sticky=ttk.E, padx=(10, 0), pady=10)
+        self.uptime_label.grid(row=0, column=1, sticky=E, padx=(10, 0), pady=10)
         
         self.latency_label = ttk.Label(wrapper, text=f"Latency: {self.bot_controller.get_latency()}", font=font)
         self.latency_label.configure(background=self.root.style.colors.get("dark"))
-        self.latency_label.grid(row=0, column=2, sticky=ttk.E, padx=10, pady=10)
+        self.latency_label.grid(row=0, column=2, sticky=E, padx=10, pady=10)
         
         wrapper.grid_columnconfigure(1, weight=1)
         

--- a/gui/pages/onboarding.py
+++ b/gui/pages/onboarding.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import threading
 
 from utils.config import Config
@@ -62,7 +63,7 @@ class OnboardingPage:
         
     def _draw_token_entry(self, parent):
         entry_wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        # entry_wrapper.pack(fill=ttk.BOTH, padx=30, pady=30)
+        # entry_wrapper.pack(fill=BOTH, padx=30, pady=30)
         
         def _focus_in(_):
             if self.token_entry.get() == self.token_entry_placeholder:
@@ -76,21 +77,21 @@ class OnboardingPage:
         
         label = ttk.Label(entry_wrapper, text="Token", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         label.configure(background=self.root.style.colors.get("dark"))
-        label.grid(row=0, column=0, sticky=ttk.W, padx=(12, 0), pady=(10, 8))
+        label.grid(row=0, column=0, sticky=W, padx=(12, 0), pady=(10, 8))
         
         self.token_entry = ttk.Entry(entry_wrapper, bootstyle="dark.TFrame", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.token_entry.insert(0, self.token_entry_placeholder)
         self.token_entry.configure(foreground="grey", background="#1a1c1c")
         self.token_entry.bind("<FocusIn>", _focus_in)
         self.token_entry.bind("<FocusOut>", _focus_out)
-        self.token_entry.grid(row=0, column=1, sticky=ttk.EW, padx=(8, 10), pady=(10, 8), ipady=10, ipadx=10)
+        self.token_entry.grid(row=0, column=1, sticky=EW, padx=(8, 10), pady=(10, 8), ipady=10, ipadx=10)
         entry_wrapper.grid_columnconfigure(1, weight=1)
             
         return entry_wrapper
     
     def _draw_prefix_entry(self, parent):
         entry_wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        # entry_wrapper.pack(fill=ttk.BOTH, padx=30, pady=30)
+        # entry_wrapper.pack(fill=BOTH, padx=30, pady=30)
         
         def _focus_in(_):
             if self.prefix_entry.get() == self.prefix_entry_placeholder:
@@ -104,14 +105,14 @@ class OnboardingPage:
         
         label = ttk.Label(entry_wrapper, text="Prefix", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         label.configure(background=self.root.style.colors.get("dark"))
-        label.grid(row=0, column=0, sticky=ttk.W, padx=(12, 0), pady=(10, 8))
+        label.grid(row=0, column=0, sticky=W, padx=(12, 0), pady=(10, 8))
         
         self.prefix_entry = ttk.Entry(entry_wrapper, bootstyle="dark.TFrame", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
         self.prefix_entry.insert(0, self.prefix_entry_placeholder)
         self.prefix_entry.configure(foreground="grey", background="#1a1c1c")
         self.prefix_entry.bind("<FocusIn>", _focus_in)
         self.prefix_entry.bind("<FocusOut>", _focus_out)
-        self.prefix_entry.grid(row=0, column=1, sticky=ttk.EW, padx=(8, 10), pady=(10, 8), ipady=10, ipadx=10)
+        self.prefix_entry.grid(row=0, column=1, sticky=EW, padx=(8, 10), pady=(10, 8), ipady=10, ipadx=10)
         entry_wrapper.grid_columnconfigure(1, weight=1)
         
         prefix = self.cfg.get("prefix")
@@ -125,7 +126,7 @@ class OnboardingPage:
     def _draw_webhook_setup(self, parent):
         wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
         inner_wrapper = ttk.Frame(wrapper, style="dark.TFrame")
-        inner_wrapper.pack(fill=ttk.BOTH, padx=10, pady=10)
+        inner_wrapper.pack(fill=BOTH, padx=10, pady=10)
 
         # Configure grid columns to have equal weight
         inner_wrapper.grid_columnconfigure(0, weight=1, minsize=150)
@@ -134,26 +135,26 @@ class OnboardingPage:
 
         # Left Side - Text
         text_wrapper = ttk.Frame(inner_wrapper, style="dark.TFrame")
-        # text_wrapper.pack(fill=ttk.BOTH, side=ttk.LEFT, expand=True)
-        text_wrapper.grid(row=0, column=0, sticky=ttk.NSEW, pady=(0, 4), padx=(2, 0))
+        # text_wrapper.pack(fill=BOTH, side=LEFT, expand=True)
+        text_wrapper.grid(row=0, column=0, sticky=NSEW, pady=(0, 4), padx=(2, 0))
 
         title = ttk.Label(text_wrapper, text="Webhook Setup", font=("Host Grotesk", 14 if sys.platform != "darwin" else 20, "bold"))
         title.configure(background=self.root.style.colors.get("dark"))
-        title.grid(row=0, column=0, sticky=ttk.W)
+        title.grid(row=0, column=0, sticky=W)
 
         description = ttk.Label(text_wrapper, text="Do you want Ghost to create a fresh server for sniper webhooks and rich embeds?", wraplength=180)
         description.configure(background=self.root.style.colors.get("dark"))
-        description.grid(row=1, column=0, sticky=ttk.W)
+        description.grid(row=1, column=0, sticky=W)
 
         button_wrapper = ttk.Frame(text_wrapper, style="dark.TFrame")
         button_wrapper.grid(row=2, column=0, sticky="SEW", pady=(10, 0))
         text_wrapper.grid_rowconfigure(2, weight=1)
 
         continue_button = RoundedButton(button_wrapper, text="Continue", style="primary.TButton", command=lambda _: self._start(True))
-        continue_button.grid(row=0, column=0, sticky=ttk.EW, padx=(0, 5))
+        continue_button.grid(row=0, column=0, sticky=EW, padx=(0, 5))
 
         skip_button = RoundedButton(button_wrapper, text="Skip", style="danger.TButton", command=lambda _: self._start(False))
-        skip_button.grid(row=0, column=1, sticky=ttk.EW)
+        skip_button.grid(row=0, column=1, sticky=EW)
         
         button_wrapper.grid_columnconfigure(0, weight=1, uniform="buttons")
         button_wrapper.grid_columnconfigure(1, weight=1, uniform="buttons")
@@ -166,8 +167,8 @@ class OnboardingPage:
         
         webhooks_preview = ttk.Label(inner_wrapper, image=ghost_webhook_image)
         webhooks_preview.configure(background=self.root.style.colors.get("dark"))
-        # webhooks_preview.pack(fill=ttk.BOTH, side=ttk.RIGHT)
-        webhooks_preview.grid(row=0, column=1, sticky=ttk.NE, padx=(10, 0))
+        # webhooks_preview.pack(fill=BOTH, side=RIGHT)
+        webhooks_preview.grid(row=0, column=1, sticky=NE, padx=(10, 0))
 
         return wrapper
         
@@ -176,10 +177,10 @@ class OnboardingPage:
         wrapper.place(relx=0.5, rely=0.5, anchor="center")
         
         token_entry = self._draw_token_entry(wrapper)
-        token_entry.pack(fill=ttk.BOTH, padx=30, pady=(30, 0))
+        token_entry.pack(fill=BOTH, padx=30, pady=(30, 0))
         
         prefix_entry = self._draw_prefix_entry(wrapper)
-        prefix_entry.pack(fill=ttk.BOTH, padx=30, pady=10)
+        prefix_entry.pack(fill=BOTH, padx=30, pady=10)
         
         webhooks_setup = self._draw_webhook_setup(wrapper)
-        webhooks_setup.pack(fill=ttk.BOTH, padx=30, pady=(0, 30))
+        webhooks_setup.pack(fill=BOTH, padx=30, pady=(0, 30))

--- a/gui/pages/script.py
+++ b/gui/pages/script.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 
 from utils.files import get_application_support
 from gui.helpers.images import Images
@@ -26,27 +27,27 @@ class ScriptPage:
         
     def _save_script(self):
         # with open(get_application_support() + f"/scripts/{self.script}", "w") as file:
-        #     file.write(self.editor.content.get("1.0", ttk.END))
+        #     file.write(self.editor.content.get("1.0", END))
         self.editor.save()
 
     def _draw_header(self, parent):
         wrapper = ttk.Frame(parent)
         
         back_button = ttk.Label(wrapper, image=self.images.get("left-chevron"))
-        back_button.grid(row=0, column=0, sticky=ttk.W, padx=(0, 10))
+        back_button.grid(row=0, column=0, sticky=W, padx=(0, 10))
         back_button.bind("<Button-1>", lambda e: self._go_back())
             
         script_name = ttk.Label(wrapper, text=self.script, font=("Host Grotesk", 16, "bold"))
-        script_name.grid(row=0, column=1, sticky=ttk.W)
+        script_name.grid(row=0, column=1, sticky=W)
         
         return wrapper
 
     def draw(self, parent):
         header = self._draw_header(parent)
-        header.pack(fill=ttk.X, pady=(0, 20))
+        header.pack(fill=X, pady=(0, 20))
         
         editor_wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        editor_wrapper.pack(fill=ttk.BOTH, expand=True)
+        editor_wrapper.pack(fill=BOTH, expand=True)
 
         self.editor = Editor(
             editor_wrapper, 
@@ -56,6 +57,6 @@ class ScriptPage:
             path=get_application_support() + f"/scripts/{self.script}",
             showpath=False
         )
-        self.editor.pack(fill=ttk.BOTH, expand=True)
+        self.editor.pack(fill=BOTH, expand=True)
         content = self.editor.content
         content.insert("end", self._get_script_content())

--- a/gui/pages/scripts.py
+++ b/gui/pages/scripts.py
@@ -1,6 +1,7 @@
 import os, sys
 import subprocess
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 
 from ttkbootstrap.scrolled import ScrolledFrame
 from ttkbootstrap.dialogs import Messagebox
@@ -62,7 +63,7 @@ class ScriptsPage:
         if current_scripts != previous_scripts:
             try:
                 if not self.restart_warning.winfo_ismapped():
-                    self.restart_warning.pack(fill=ttk.X, side=ttk.TOP, pady=(10, 0))
+                    self.restart_warning.pack(fill=X, side=TOP, pady=(10, 0))
             except:
                 pass
         else:
@@ -81,7 +82,7 @@ class ScriptsPage:
         for script in files:
             if script not in current_scripts:
                 script_frame = self._draw_script_frame(self.scripts_wrapper, script)
-                script_frame.pack(fill=ttk.X, pady=5)
+                script_frame.pack(fill=X, pady=5)
                 self.script_frames.append({
                     "name": script,
                     "frame": script_frame
@@ -131,22 +132,22 @@ class ScriptsPage:
        
         if search_query == "":
             for frame in self.script_frames:
-                frame["frame"].pack(fill=ttk.X, pady=5)
+                frame["frame"].pack(fill=X, pady=5)
             return
             
         for frame in self.script_frames:
             if search_query.lower() in frame["name"].lower():
-                frame["frame"].pack(fill=ttk.X, pady=5)
+                frame["frame"].pack(fill=X, pady=5)
         
     def _draw_search_bar(self, parent):
         entry_wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="secondary.TFrame")
-        # entry_wrapper.pack(fill=ttk.BOTH)
+        # entry_wrapper.pack(fill=BOTH)
         
         placeholder_text = "Search local scripts..."
         
         def on_focus_in(event):
             if self.search_entry.get() == placeholder_text:
-                self.search_entry.delete(0, ttk.END)
+                self.search_entry.delete(0, END)
                 self.search_entry.configure(foreground=self.root.style.colors.get("fg"))
                 
         def on_focus_out(event):
@@ -155,7 +156,7 @@ class ScriptsPage:
                 self.search_entry.configure(foreground=Style.LIGHT_GREY.value)
         
         self.search_entry = ttk.Entry(entry_wrapper, bootstyle="secondary.TFrame", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
-        self.search_entry.grid(row=0, column=0, sticky=ttk.EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
+        self.search_entry.grid(row=0, column=0, sticky=EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
         self.search_entry.configure(foreground=Style.LIGHT_GREY.value)
         self.search_entry.insert(0, placeholder_text)
         self.search_entry.bind("<FocusIn>", on_focus_in)
@@ -164,7 +165,7 @@ class ScriptsPage:
         # self.search_entry.bind("<Key>", self._search_scripts)
         
         search_button = ttk.Label(entry_wrapper, image=self.images.get("search"), style="secondary.TButton")
-        search_button.grid(row=0, column=2, sticky=ttk.E, padx=(0, 10), pady=10)
+        search_button.grid(row=0, column=2, sticky=E, padx=(0, 10), pady=10)
         search_button.bind("<Button-1>", self._search_scripts)
         
         entry_wrapper.columnconfigure(1, weight=1)
@@ -187,7 +188,7 @@ class ScriptsPage:
         
         open_folder_button = ttk.Label(wrapper, image=self.images.get("folder-open"), style="secondary")
         open_folder_button.configure(background=self.root.style.colors.get("secondary"))
-        open_folder_button.pack(side=ttk.LEFT, padx=15, pady=14)
+        open_folder_button.pack(side=LEFT, padx=15, pady=14)
         open_folder_button.bind("<Button-1>", lambda e: open_path_in_explorer(get_application_support() + "/scripts"))
         open_folder_button.bind("<Enter>", _hover_enter)
         open_folder_button.bind("<Leave>", _hover_leave)
@@ -214,7 +215,7 @@ class ScriptsPage:
         
         plus_button = ttk.Label(wrapper, image=self.plus_button_image, style="primary")
         plus_button.configure(background=self.root.style.colors.get("primary"))
-        plus_button.pack(side=ttk.LEFT, padx=15, pady=14)
+        plus_button.pack(side=LEFT, padx=15, pady=14)
         plus_button.bind("<Button-1>", lambda e: self._create_script())
         plus_button.bind("<Enter>", _hover_enter)
         plus_button.bind("<Leave>", _hover_leave)
@@ -225,13 +226,13 @@ class ScriptsPage:
         header = ttk.Frame(parent)
         
         search_bar = self._draw_search_bar(header)
-        search_bar.grid(row=0, column=0, sticky=ttk.EW, padx=(0, 5))
+        search_bar.grid(row=0, column=0, sticky=EW, padx=(0, 5))
         
         open_folder_button = self._draw_open_folder_button(header)
-        open_folder_button.grid(row=0, column=1, sticky=ttk.E)
+        open_folder_button.grid(row=0, column=1, sticky=E)
         
         plus_button = self._draw_plus_button(header)
-        plus_button.grid(row=0, column=2, sticky=ttk.E, padx=(5, 0))
+        plus_button.grid(row=0, column=2, sticky=E, padx=(5, 0))
         
         header.grid_columnconfigure(0, weight=1)
         
@@ -242,15 +243,15 @@ class ScriptsPage:
 
         frame = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
         inner_wrapper = ttk.Frame(frame, style="dark.TFrame")
-        inner_wrapper.pack(fill=ttk.BOTH, padx=(15, 10), pady=10)
+        inner_wrapper.pack(fill=BOTH, padx=(15, 10), pady=10)
 
         script_name = ttk.Label(inner_wrapper, text=script, font=("Host Grotesk", 14 if sys.platform != "darwin" else 16, "bold"))
         script_name.configure(background=self.root.style.colors.get("dark"))
-        script_name.grid(row=0, column=0, sticky=ttk.W)
+        script_name.grid(row=0, column=0, sticky=W)
         inner_wrapper.columnconfigure(0, weight=1)
 
         button_wrapper = ttk.Frame(inner_wrapper, style="dark.TFrame", width=60, height=20)
-        button_wrapper.grid(row=0, column=1, sticky=ttk.E)
+        button_wrapper.grid(row=0, column=1, sticky=E)
 
         self.hover_images = {}
         buttons = {
@@ -293,14 +294,14 @@ class ScriptsPage:
     def _draw_scripts(self, parent):
         scripts = self.cfg.get_scripts()
         self.scripts_wrapper = ScrolledFrame(parent, width=parent.winfo_width(), height=parent.winfo_height())
-        self.scripts_wrapper.pack(fill=ttk.BOTH, expand=True)
+        self.scripts_wrapper.pack(fill=BOTH, expand=True)
         
         self.scripts_wrapper.hide_scrollbars()
         self.scripts_wrapper.enable_scrolling()
         
         for script in scripts:
             script_frame = self._draw_script_frame(self.scripts_wrapper, script)
-            script_frame.pack(fill=ttk.X, pady=5)
+            script_frame.pack(fill=X, pady=5)
             
             self.script_frames.append({
                 "name": script,
@@ -310,28 +311,28 @@ class ScriptsPage:
     def _draw_restart_warning(self, parent):
         wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="warning.TFrame")
         inner_wrapper = ttk.Frame(wrapper, style="warning.TFrame")
-        inner_wrapper.pack(fill=ttk.BOTH, padx=15, pady=10, expand=True)
+        inner_wrapper.pack(fill=BOTH, padx=15, pady=10, expand=True)
         
         warning_label = ttk.Label(inner_wrapper, text="A restart is required to apply changes!", font=("Host Grotesk", 14 if sys.platform != "darwin" else 16, "bold"), anchor="center")
         warning_label.configure(background=self.root.style.colors.get("warning"))
-        warning_label.pack(fill=ttk.BOTH, expand=True)
+        warning_label.pack(fill=BOTH, expand=True)
         
         return wrapper
     
     def draw(self, parent):
         self.restart_warning = self._draw_restart_warning(parent)
-        self.restart_warning.pack(fill=ttk.X, side=ttk.TOP, pady=(10, 0))
+        self.restart_warning.pack(fill=X, side=TOP, pady=(10, 0))
         self.restart_warning.pack_forget()
         
         title = ttk.Label(parent, text="Scripts", font=("Host Grotesk", 24, "bold"))
         title.configure(background=self.root.style.colors.get("bg"))
-        title.pack(pady=(0, 15), anchor=ttk.W)
-        # title.grid(row=0, column=0, sticky=ttk.W, pady=(0, 15))
+        title.pack(pady=(0, 15), anchor=W)
+        # title.grid(row=0, column=0, sticky=W, pady=(0, 15))
         
         header = self._draw_header(parent)
-        header.pack(fill=ttk.X)
+        header.pack(fill=X)
         
-        ttk.Separator(parent, orient="horizontal").pack(fill=ttk.X, pady=(20, 16), padx=4)
+        ttk.Separator(parent, orient="horizontal").pack(fill=X, pady=(20, 16), padx=4)
         
         self._draw_scripts(parent)
         self._listen_to_directory()

--- a/gui/pages/settings.py
+++ b/gui/pages/settings.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components.settings import GeneralPanel, ThemingPanel, APIsPanel, SessionSpoofingPanel, RichPresencePanel, SnipersPanel
 from gui.components import RoundedFrame, DropdownMenu
 from gui.helpers import Images, Style
@@ -53,9 +54,9 @@ class SettingsPage:
         self.apis = APIsPanel(self.root, general_wrapper, self.images, self.cfg).draw()
         self.theming = ThemingPanel(self.root, wrapper, self.images, self.cfg, bot_controller=self.bot_controller).draw()
         
-        self.general.pack(fill=ttk.BOTH, expand=True, pady=(0, 10))
-        self.session_spoofing.pack(fill=ttk.BOTH, expand=True, pady=(0, 10))
-        self.apis.pack(fill=ttk.BOTH, expand=True, pady=(0, 10))
+        self.general.pack(fill=BOTH, expand=True, pady=(0, 10))
+        self.session_spoofing.pack(fill=BOTH, expand=True, pady=(0, 10))
+        self.apis.pack(fill=BOTH, expand=True, pady=(0, 10))
         
         self.pages["general"] = general_wrapper
         self.pages["theming"] = self.theming
@@ -77,10 +78,10 @@ class SettingsPage:
             label.configure(background=self.root.style.colors.get("secondary"))
         
         pill = RoundedFrame(parent, radius=10, bootstyle="secondary.TFrame")
-        pill.grid(row=0, column=row, sticky=ttk.W, padx=(5, 0 if text != "Snipers" else 5), pady=5)
+        pill.grid(row=0, column=row, sticky=W, padx=(5, 0 if text != "Snipers" else 5), pady=5)
         label = ttk.Label(pill, text=text, font=("Host Grotesk", 14))
         label.configure(background=self.root.style.colors.get("secondary"))
-        label.grid(row=0, column=0, sticky=ttk.W, padx=5, pady=5)
+        label.grid(row=0, column=0, sticky=W, padx=5, pady=5)
         label.bind("<Button-1>", lambda e: command())
         pill.bind("<Button-1>", lambda e: command())
         pill.bind("<Enter>", lambda e: _hover_enter(e, pill, label))
@@ -93,7 +94,7 @@ class SettingsPage:
         if key != self.current_page:
             for page in self.pages.values():
                 page.pack_forget()
-            self.pages[key].pack(fill=ttk.BOTH, expand=True, pady=(0, 10))
+            self.pages[key].pack(fill=BOTH, expand=True, pady=(0, 10))
             self.current_page = key
         
         for pill_key, pill_components in self.pills.items():
@@ -110,10 +111,10 @@ class SettingsPage:
 
         self.title = ttk.Label(parent, text="Settings", font=("Host Grotesk", 24, "bold"))
         self.title.configure(background=self.root.style.colors.get("bg"))
-        self.title.pack(pady=(0, 10), anchor=ttk.W)
+        self.title.pack(pady=(0, 10), anchor=W)
 
         self.pages_wrapper = RoundedFrame(parent, radius=15, bootstyle="dark.TFrame")
-        self.pages_wrapper.pack(anchor=ttk.W)
+        self.pages_wrapper.pack(anchor=W)
         
         self._create_pill(self.pages_wrapper, "General", 0, lambda: self.toggle("general"))
         self._create_pill(self.pages_wrapper, "Theming", 1, lambda: self.toggle("theming"))
@@ -124,6 +125,6 @@ class SettingsPage:
         
         # -------
         
-        self.settings_wrapper.pack(fill=ttk.BOTH, expand=True, pady=(10, 0))
-        self.pages[self.current_page].pack(fill=ttk.BOTH, expand=True, pady=(0, 10))
+        self.settings_wrapper.pack(fill=BOTH, expand=True, pady=(10, 0))
+        self.pages[self.current_page].pack(fill=BOTH, expand=True, pady=(0, 10))
         self.toggle(self.current_page)

--- a/gui/pages/tools/message_logger_page.py
+++ b/gui/pages/tools/message_logger_page.py
@@ -1,5 +1,6 @@
 import webbrowser, discord, sys, time
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 import tkinter.font as tkFont
 from ttkbootstrap.scrolled import ScrolledFrame
 from gui.components import RoundedFrame, ToolPage
@@ -25,15 +26,15 @@ class MessageLoggerPage(ToolPage):
         wrapper = ttk.Frame(parent)
 
         tools_label = ttk.Label(wrapper, text="Tools", font=("Host Grotesk", 24, "bold"), foreground=Style.LIGHT_GREY.value)
-        tools_label.grid(row=0, column=0, sticky=ttk.W)
+        tools_label.grid(row=0, column=0, sticky=W)
         tools_label.bind("<Button-1>", lambda e: self.go_back())
 
         back_button = ttk.Label(wrapper, image=self.images.get("right-chevron-small"))
         back_button.bind("<Button-1>", lambda e: self.go_back())
-        back_button.grid(row=0, column=1, sticky=ttk.W, padx=(10, 10))
+        back_button.grid(row=0, column=1, sticky=W, padx=(10, 10))
 
         page_name = ttk.Label(wrapper, text=self.title, font=("Host Grotesk", 24, "bold"))
-        page_name.grid(row=0, column=2, sticky=ttk.W)
+        page_name.grid(row=0, column=2, sticky=W)
         page_name.bind("<Button-1>", lambda e: self.go_back())
 
         clear_btn = ttk.Label(wrapper, image=self.images.get("trash"))
@@ -41,7 +42,7 @@ class MessageLoggerPage(ToolPage):
         clear_btn.bind("<Button-1>", lambda e: self._clear_discord_logs())
         clear_btn.bind("<Enter>", lambda e: clear_btn.configure(foreground=Style.LIGHT_GREY.value))
         clear_btn.bind("<Leave>", lambda e: clear_btn.configure(foreground="white"))
-        clear_btn.grid(row=0, column=3, sticky=ttk.E, padx=(20, 0))
+        clear_btn.grid(row=0, column=3, sticky=E, padx=(20, 0))
 
         wrapper.grid_columnconfigure(2, weight=1)
 
@@ -143,7 +144,7 @@ class MessageLoggerPage(ToolPage):
         self.root.bind("<Configure>", self._update_wraplength)
         
         self.discord_logs_inner_wrapper = ttk.Frame(wrapper)
-        self.discord_logs_inner_wrapper.pack(fill=ttk.BOTH, expand=True, padx=10, pady=(10, 10))
+        self.discord_logs_inner_wrapper.pack(fill=BOTH, expand=True, padx=10, pady=(10, 10))
 
         canvas = ttk.Canvas(self.discord_logs_inner_wrapper)
         scrollbar = ttk.Scrollbar(self.discord_logs_inner_wrapper, orient="vertical", command=canvas.yview)

--- a/gui/pages/tools/password_gen.py
+++ b/gui/pages/tools/password_gen.py
@@ -2,6 +2,7 @@ import sys
 import string
 import random
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components import RoundedFrame, ToolPage, RoundedButton
 from gui.helpers import Style
 
@@ -23,26 +24,26 @@ class PasswordGenPage(ToolPage):
             # set generated password text to "Copied!" for 1.5 seconds
             original_text = self.generated_password.get()
             self.generated_password.configure(state="normal")
-            self.generated_password.delete(0, ttk.END)
+            self.generated_password.delete(0, END)
             self.generated_password.insert(0, "Copied!")
             self.generated_password.configure(state="readonly")
-            self.root.after(1500, lambda: self.generated_password.configure(state="normal") or self.generated_password.delete(0, ttk.END) or self.generated_password.insert(0, original_text) or self.generated_password.configure(state="readonly"))
+            self.root.after(1500, lambda: self.generated_password.configure(state="normal") or self.generated_password.delete(0, END) or self.generated_password.insert(0, original_text) or self.generated_password.configure(state="readonly"))
         
     def draw_password_field(self, parent):
         entry_wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        entry_wrapper.pack(fill=ttk.BOTH, pady=(0, 10))
+        entry_wrapper.pack(fill=BOTH, pady=(0, 10))
         
         self.generated_password = ttk.Entry(entry_wrapper, bootstyle="dark.TFrame", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
-        self.generated_password.grid(row=0, column=0, sticky=ttk.EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
+        self.generated_password.grid(row=0, column=0, sticky=EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
         self.generated_password.insert(0, "Click 'Generate' to create a password")
         self.generated_password.configure(state="readonly")
         
         copy_button = ttk.Label(entry_wrapper, image=self.images.get("copy"), style="dark.TButton")
-        copy_button.grid(row=0, column=2, sticky=ttk.E, padx=(0, 0), pady=10)
+        copy_button.grid(row=0, column=2, sticky=E, padx=(0, 0), pady=10)
         copy_button.bind("<Button-1>", lambda e: self.copy_to_clipboard())
         
         reset_button = ttk.Label(entry_wrapper, image=self.images.get("reset"), style="dark.TButton")
-        reset_button.grid(row=0, column=3, sticky=ttk.E, padx=(0, 10), pady=10)
+        reset_button.grid(row=0, column=3, sticky=E, padx=(0, 10), pady=10)
         reset_button.bind("<Button-1>", lambda e: self.generate_password())
         
         entry_wrapper.columnconfigure(1, weight=1)
@@ -63,7 +64,7 @@ class PasswordGenPage(ToolPage):
         
         password = ''.join(random.choice(character_pool) for _ in range(self.password_length))
         self.generated_password.configure(state="normal")
-        self.generated_password.delete(0, ttk.END)
+        self.generated_password.delete(0, END)
         self.generated_password.insert(0, password)
         self.generated_password.configure(state="readonly")
         
@@ -117,58 +118,58 @@ class PasswordGenPage(ToolPage):
         
     def draw_options(self, parent):
         options_wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        options_wrapper.pack(fill=ttk.BOTH)
+        options_wrapper.pack(fill=BOTH)
         options_wrapper.columnconfigure(1, weight=1)
         
         # password strength
         strength_wrapper = ttk.Frame(options_wrapper, bootstyle="dark.TFrame")
-        strength_wrapper.grid(row=0, column=0, sticky=ttk.EW, padx=18, pady=(15, 5), columnspan=2)
+        strength_wrapper.grid(row=0, column=0, sticky=EW, padx=18, pady=(15, 5), columnspan=2)
         strength_wrapper.columnconfigure(0, weight=1)
         
         self.strength_label = ttk.Label(strength_wrapper, text="Strong", font=("Host Grotesk", 12), background=self.root.style.colors.get("dark"))
-        self.strength_label.grid(row=0, column=1, sticky=ttk.W, padx=(15, 0))
+        self.strength_label.grid(row=0, column=1, sticky=W, padx=(15, 0))
         self.strength_bar = ttk.Progressbar(strength_wrapper, bootstyle="success", maximum=100, value=80)
-        self.strength_bar.grid(row=0, column=0, sticky=ttk.EW)
+        self.strength_bar.grid(row=0, column=0, sticky=EW)
         
         # password length
         self.length_label = ttk.Label(options_wrapper, text=f"Password Length {self.password_length}", font=("Host Grotesk", 12), background=self.root.style.colors.get("dark"))
-        self.length_label.grid(row=1, column=0, sticky=ttk.W, padx=18, pady=(5, 5))
-        length_slider = ttk.Scale(options_wrapper, from_=4, to=48, orient=ttk.HORIZONTAL, command=self.update_password_length)
+        self.length_label.grid(row=1, column=0, sticky=W, padx=18, pady=(5, 5))
+        length_slider = ttk.Scale(options_wrapper, from_=4, to=48, orient=HORIZONTAL, command=self.update_password_length)
         length_slider.bind("<ButtonRelease-1>", self.on_slider_release)
         length_slider.set(self.password_length)
-        length_slider.grid(row=1, column=1, sticky=ttk.EW, padx=18, pady=(5, 5))
+        length_slider.grid(row=1, column=1, sticky=EW, padx=18, pady=(5, 5))
         
         # uppercase, lowercase, numbers, symbols
         self.uppercase_var = ttk.BooleanVar(value=self.include_uppercase)
         self.uppercase_var.trace_add("write", self.on_option_change)
         uppercase_label = ttk.Label(options_wrapper, text="Include Uppercase Letters", font=("Host Grotesk", 12), background=self.root.style.colors.get("dark"))
-        uppercase_label.grid(row=2, column=0, sticky=ttk.W, padx=(18, 0), pady=(5, 5))
+        uppercase_label.grid(row=2, column=0, sticky=W, padx=(18, 0), pady=(5, 5))
         uppercase_check = ttk.Checkbutton(options_wrapper, variable=self.uppercase_var, bootstyle="success-round-toggle", command=self.on_option_change)
-        uppercase_check.grid(row=2, column=1, sticky=ttk.E, padx=18, pady=(5, 5))
+        uppercase_check.grid(row=2, column=1, sticky=E, padx=18, pady=(5, 5))
         
         self.lowercase_var = ttk.BooleanVar(value=self.include_lowercase)
         self.lowercase_var.trace_add("write", self.on_option_change)
         lowercase_label = ttk.Label(options_wrapper, text="Include Lowercase Letters", font=("Host Grotesk", 12), background=self.root.style.colors.get("dark"))
-        lowercase_label.grid(row=3, column=0, sticky=ttk.W, padx=(18, 0), pady=(5, 5))
+        lowercase_label.grid(row=3, column=0, sticky=W, padx=(18, 0), pady=(5, 5))
         lowercase_check = ttk.Checkbutton(options_wrapper, variable=self.lowercase_var, bootstyle="success-round-toggle", command=self.on_option_change)
-        lowercase_check.grid(row=3, column=1, sticky=ttk.E, padx=18, pady=(5, 5))
+        lowercase_check.grid(row=3, column=1, sticky=E, padx=18, pady=(5, 5))
         
         self.numbers_var = ttk.BooleanVar(value=self.include_numbers)
         self.numbers_var.trace_add("write", self.on_option_change)
         numbers_label = ttk.Label(options_wrapper, text="Include Numbers", font=("Host Grotesk", 12), background=self.root.style.colors.get("dark"))
-        numbers_label.grid(row=4, column=0, sticky=ttk.W, padx=(18, 0), pady=(5, 5))
+        numbers_label.grid(row=4, column=0, sticky=W, padx=(18, 0), pady=(5, 5))
         numbers_check = ttk.Checkbutton(options_wrapper, variable=self.numbers_var, bootstyle="success-round-toggle", command=self.on_option_change)
-        numbers_check.grid(row=4, column=1, sticky=ttk.E, padx=18, pady=(5, 5))
+        numbers_check.grid(row=4, column=1, sticky=E, padx=18, pady=(5, 5))
         
         self.symbols_var = ttk.BooleanVar(value=self.include_symbols)
         self.symbols_var.trace_add("write", self.on_option_change)
         symbols_label = ttk.Label(options_wrapper, text="Include Symbols", font=("Host Grotesk", 12), background=self.root.style.colors.get("dark"))
-        symbols_label.grid(row=5, column=0, sticky=ttk.W, padx=(18, 0), pady=(5, 15))
+        symbols_label.grid(row=5, column=0, sticky=W, padx=(18, 0), pady=(5, 15))
         symbols_check = ttk.Checkbutton(options_wrapper, variable=self.symbols_var, bootstyle="success-round-toggle", command=self.on_option_change)
-        symbols_check.grid(row=5, column=1, sticky=ttk.E, padx=18, pady=(5, 15))
+        symbols_check.grid(row=5, column=1, sticky=E, padx=18, pady=(5, 15))
         
         # generate_button = RoundedButton(options_wrapper, text="Generate", bootstyle="success.TButton", command=self.generate_password)
-        # generate_button.grid(row=6, column=1, columnspan=2, pady=(0, 15), padx=18, sticky=ttk.E)
+        # generate_button.grid(row=6, column=1, columnspan=2, pady=(0, 15), padx=18, sticky=E)
         
     def draw_content(self, wrapper):
         self.draw_password_field(wrapper)

--- a/gui/pages/tools/surveillance_page.py
+++ b/gui/pages/tools/surveillance_page.py
@@ -1,5 +1,6 @@
 import sys, time, json, os
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from ttkbootstrap.scrolled import ScrolledFrame
 from ttkbootstrap.tableview import Tableview
 from gui.components import ToolPage, RoundedFrame, RoundedButton
@@ -43,7 +44,7 @@ class SurveillancePage(ToolPage):
         if self.user_wrapper:
             self.user_wrapper.destroy()
         self.user_wrapper = self._draw_user_wrapper(self.user_progress_wrapper)
-        self.user_wrapper.pack(side=ttk.BOTTOM, fill=ttk.BOTH, expand=True)
+        self.user_wrapper.pack(side=BOTTOM, fill=BOTH, expand=True)
         self.user_wrapper.set_width(200)
 
     def _check_mutual_guilds(self):
@@ -98,7 +99,7 @@ class SurveillancePage(ToolPage):
             self.root.after(50, lambda: self._configure_start_stop_button(True))
 
             if not self.search_button.winfo_ismapped():
-                self.search_button.grid(row=0, column=2, sticky=ttk.E, padx=(0, 10), pady=10)
+                self.search_button.grid(row=0, column=2, sticky=E, padx=(0, 10), pady=10)
         else:
             self.search_placeholder_text = "Search a Discord user ID..."
             self.messages_textarea_updating = False
@@ -111,14 +112,14 @@ class SurveillancePage(ToolPage):
         if not self.surveillance.running and len(self.messages_all) > 0:
             self.search_placeholder_text = "Search for a message..."
             if not self.search_button.winfo_ismapped():
-                self.search_button.grid(row=0, column=2, sticky=ttk.E, padx=(0, 10), pady=10)
+                self.search_button.grid(row=0, column=2, sticky=E, padx=(0, 10), pady=10)
         # elif self.surveillance.running and len(self.messages_all) > 0:
         #     self.search_placeholder_text = "Search for a message..."
                 
         try:
             self.search_entry.configure(foreground="grey")
             self.search_var.set("")
-            self.search_entry.delete(0, ttk.END)
+            self.search_entry.delete(0, END)
             self.search_entry.insert(0, self.search_placeholder_text)
         except Exception as e:
             print(f"Error resetting search entry: {e}")
@@ -219,7 +220,7 @@ class SurveillancePage(ToolPage):
         
         self.start_stop_button = ttk.Label(wrapper, image=self.play_button_image, style="primary")
         self.start_stop_button.configure(background=self.root.style.colors.get("primary"))
-        self.start_stop_button.pack(side=ttk.LEFT, padx=15, pady=14)
+        self.start_stop_button.pack(side=LEFT, padx=15, pady=14)
         self.start_stop_button.bind("<Button-1>", lambda e: self._toggle_surveillance())
         self.start_stop_button.bind("<Enter>", _hover_enter)
         self.start_stop_button.bind("<Leave>", _hover_leave)
@@ -250,7 +251,7 @@ class SurveillancePage(ToolPage):
         
         self.reset_button = ttk.Label(self.reset_button_wrapper, image=self.reset_button_image, style="danger" if not self.reset_button_disabled else "dark")
         self.reset_button.configure(background=self.root.style.colors.get("danger") if not self.reset_button_disabled else self.root.style.colors.get("dark"))
-        self.reset_button.pack(side=ttk.LEFT, padx=15, pady=14)
+        self.reset_button.pack(side=LEFT, padx=15, pady=14)
         self.reset_button.bind("<Button-1>", _reset)
         self.reset_button.bind("<Enter>", _hover_enter)
         self.reset_button.bind("<Leave>", _hover_leave)
@@ -295,7 +296,7 @@ class SurveillancePage(ToolPage):
         
         download_icon = ttk.Label(download_button, image=self.images.get("download"), style="dark")
         download_icon.configure(background=self.root.style.colors.get("dark"))
-        download_icon.pack(side=ttk.LEFT, padx=(15), pady=14)
+        download_icon.pack(side=LEFT, padx=(15), pady=14)
         download_icon.bind("<Button-1>", lambda e: self._download_data())
         download_icon.bind("<Enter>", lambda e: _hover_enter(e))
         download_icon.bind("<Leave>", lambda e: _hover_leave(e))
@@ -307,7 +308,7 @@ class SurveillancePage(ToolPage):
 
         def on_focus_in(event):
             if self.search_entry.get() == self.search_placeholder_text:
-                self.search_entry.delete(0, ttk.END)
+                self.search_entry.delete(0, END)
                 self.search_entry.configure(foreground=self.root.style.colors.get("fg"))
 
         def on_focus_out(event):
@@ -324,7 +325,7 @@ class SurveillancePage(ToolPage):
             textvariable=self.search_var,
             font=("Host Grotesk", 12 if sys.platform != "darwin" else 13)
         )
-        self.search_entry.grid(row=0, column=0, sticky=ttk.EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
+        self.search_entry.grid(row=0, column=0, sticky=EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
 
         self.search_entry.insert(0, self.search_placeholder_text)
         self.search_entry.configure(foreground=Style.LIGHT_GREY.value)
@@ -341,16 +342,16 @@ class SurveillancePage(ToolPage):
         header = ttk.Frame(parent)
         
         search_bar = self._draw_search_bar(header)
-        search_bar.grid(row=0, column=0, sticky=ttk.EW, padx=(0, 5))
+        search_bar.grid(row=0, column=0, sticky=EW, padx=(0, 5))
         
         start_stop_button = self._draw_start_stop_button(header)
-        start_stop_button.grid(row=0, column=1, sticky=ttk.E)
+        start_stop_button.grid(row=0, column=1, sticky=E)
         
         reset_button = self._draw_reset_button(header)
-        reset_button.grid(row=0, column=2, sticky=ttk.E, padx=(5, 5))
+        reset_button.grid(row=0, column=2, sticky=E, padx=(5, 5))
         
         download_button = self._draw_download_button(header)
-        download_button.grid(row=0, column=3, sticky=ttk.E)
+        download_button.grid(row=0, column=3, sticky=E)
         
         header.grid_columnconfigure(0, weight=1)
         
@@ -422,7 +423,7 @@ class SurveillancePage(ToolPage):
         if self.user_avatar:
             accent_colour_banner = RoundedFrame(wrapper, radius=(15, 15, 0, 0), background=self.user_banner_colour, parent_background=self.root.style.colors.get("bg"))
             accent_colour_banner.set_height(85)
-            accent_colour_banner.pack(side=ttk.TOP, fill=ttk.X)
+            accent_colour_banner.pack(side=TOP, fill=X)
             accent_colour_banner.columnconfigure(0, weight=1)
             
             avatar_label = ttk.Canvas(wrapper, width=100, height=200, background=self.user_banner_colour, highlightthickness=0)
@@ -438,7 +439,7 @@ class SurveillancePage(ToolPage):
             
         if self.user:
             user_info_wrapper = ttk.Frame(wrapper, style="dark.TFrame")
-            user_info_wrapper.pack(side=ttk.TOP, fill=ttk.X, pady=(35, 0), padx=(10, 10))
+            user_info_wrapper.pack(side=TOP, fill=X, pady=(35, 0), padx=(10, 10))
             user_info_wrapper.configure(height=50)
             
             display_name = ttk.Label(user_info_wrapper, text=self.user.display_name, font=("Host Grotesk", 16 if sys.platform != "darwin" else 18, "bold"))
@@ -452,21 +453,21 @@ class SurveillancePage(ToolPage):
             if self.mutual_guilds:
                 mutual_guilds_subtitle = ttk.Label(wrapper, text="Mutual Guilds", font=("Host Grotesk", 12 if sys.platform != "darwin" else 14, "bold"))
                 mutual_guilds_subtitle.configure(background=self.root.style.colors.get("dark"), foreground="white")
-                mutual_guilds_subtitle.pack(side=ttk.TOP, fill=ttk.X, padx=10)
+                mutual_guilds_subtitle.pack(side=TOP, fill=X, padx=10)
                 
                 guilds_wrapper = ScrolledFrame(wrapper, bootstyle="dark.TFrame", autohide=True)
                 guilds_wrapper.container.configure(style="dark.TFrame")
-                guilds_wrapper.pack(side=ttk.TOP, fill=ttk.BOTH, pady=(3, 10), padx=(10, 10), expand=True)
+                guilds_wrapper.pack(side=TOP, fill=BOTH, pady=(3, 10), padx=(10, 10), expand=True)
                 guilds_wrapper.columnconfigure(0, weight=1)
                 
                 row = 0
                 for guild in self.mutual_guilds:
                     guild_frame = RoundedFrame(guilds_wrapper, radius=5, bootstyle="secondary.TFrame")
-                    guild_frame.grid(row=row, column=0, sticky=ttk.EW, pady=(0, 5))
+                    guild_frame.grid(row=row, column=0, sticky=EW, pady=(0, 5))
                     
                     guild_label = ttk.Label(guild_frame, text=guild.name, font=("Host Grotesk", 10 if sys.platform != "darwin" else 12))
                     guild_label.configure(background=self.root.style.colors.get("secondary"), foreground="white")
-                    guild_label.grid(row=0, column=0, sticky=ttk.EW, padx=5, pady=5)
+                    guild_label.grid(row=0, column=0, sticky=EW, padx=5, pady=5)
                     guild_frame.grid_columnconfigure(0, weight=1)
                     
                     row += 1
@@ -491,7 +492,7 @@ class SurveillancePage(ToolPage):
             # if self.search_entry:
             #     self.search_entry.configure(foreground="grey")
             #     self.search_var.set("")  # Resets the actual entry content
-            #     self.search_entry.delete(0, ttk.END)
+            #     self.search_entry.delete(0, END)
             #     self.search_entry.insert(0, self.search_placeholder_text)
 
             print("Messages fully cleared.")
@@ -611,10 +612,10 @@ class SurveillancePage(ToolPage):
         self.wrapper = wrapper
         
         header = self._draw_header(wrapper)
-        header.pack(side=ttk.TOP, fill=ttk.X, pady=(0, 10))
+        header.pack(side=TOP, fill=X, pady=(0, 10))
 
         self.msgs_logs_wrapper = ttk.Frame(wrapper)
-        self.msgs_logs_wrapper.pack(side=ttk.LEFT, fill=ttk.BOTH, expand=True, padx=(0, 5))
+        self.msgs_logs_wrapper.pack(side=LEFT, fill=BOTH, expand=True, padx=(0, 5))
         self.msgs_logs_wrapper.columnconfigure(0, weight=1)
         self.msgs_logs_wrapper.rowconfigure(0, weight=1)
         self.msgs_logs_wrapper.rowconfigure(1, weight=0)
@@ -627,16 +628,16 @@ class SurveillancePage(ToolPage):
         self.log_wrapper.grid(row=1, column=0, sticky="ew")
 
         self.user_progress_wrapper = ttk.Frame(wrapper)
-        self.user_progress_wrapper.pack(side=ttk.RIGHT, fill=ttk.Y, expand=False, padx=(5, 0))
+        self.user_progress_wrapper.pack(side=RIGHT, fill=Y, expand=False, padx=(5, 0))
         
         self.progress_wrapper = self._draw_progress_wrapper(self.user_progress_wrapper)
         self.progress_wrapper.set_height(55)
         self.progress_wrapper.set_width(200)  # fixed width
-        self.progress_wrapper.pack(side=ttk.TOP, fill=ttk.X, pady=(0, 10))
+        self.progress_wrapper.pack(side=TOP, fill=X, pady=(0, 10))
 
         self.user_wrapper = self._draw_user_wrapper(self.user_progress_wrapper)
         self.user_wrapper.set_width(200)  # fixed width
-        self.user_wrapper.pack(side=ttk.BOTTOM, fill=ttk.BOTH, expand=True)
+        self.user_wrapper.pack(side=BOTTOM, fill=BOTH, expand=True)
         
         self.update()
         

--- a/gui/pages/tools/tools.py
+++ b/gui/pages/tools/tools.py
@@ -1,5 +1,6 @@
 import os, sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 
 from gui.components import RoundedFrame
 from gui.pages.tools.surveillance_page import SurveillancePage
@@ -103,19 +104,19 @@ class ToolsPage:
         page_wrapper = RoundedFrame(parent, radius=15, bootstyle="dark.TFrame")
         page_wrapper.bind("<Button-1>", lambda e, cmd=page["command"]: cmd())
 
-        page_title = ttk.Label(page_wrapper, text=page["name"], font=("Host Grotesk", 18, "bold"), justify=ttk.CENTER)
+        page_title = ttk.Label(page_wrapper, text=page["name"], font=("Host Grotesk", 18, "bold"), justify=CENTER)
         page_title.configure(background=self.root.style.colors.get("dark"))
         page_title.grid(row=0, column=0, pady=(25, 5))
         page_title.bind("<Button-1>", lambda e, cmd=page["command"]: cmd())
 
-        page_description = ttk.Label(page_wrapper, text=page["description"], wraplength=175, justify=ttk.CENTER)
+        page_description = ttk.Label(page_wrapper, text=page["description"], wraplength=175, justify=CENTER)
         page_description.configure(background=self.root.style.colors.get("dark"), foreground=Style.LIGHT_GREY.value)
         page_description.grid(row=1, column=0, pady=(0, 25))
         page_description.bind("<Button-1>", lambda e, cmd=page["command"]: cmd())
         
         # page_icon = ttk.Label(page_wrapper, image=self.images.get("right-chevron"))
         # page_icon.configure(background=self.root.style.colors.get("dark"))
-        # page_icon.grid(row=0, column=1, sticky=ttk.E, padx=(0, 20), pady=15)
+        # page_icon.grid(row=0, column=1, sticky=E, padx=(0, 20), pady=15)
         
         page_wrapper.grid_columnconfigure(0, weight=1)
         page_wrapper.grid_rowconfigure(0, weight=1)
@@ -130,8 +131,8 @@ class ToolsPage:
     def draw(self, parent):
         title = ttk.Label(parent, text="Tools", font=("Host Grotesk", 24, "bold"))
         title.configure(background=self.root.style.colors.get("bg"))
-        # title.pack(pady=(0, 15), anchor=ttk.W)
-        title.grid(row=0, column=0, sticky=ttk.W, pady=(0, 10))
+        # title.pack(pady=(0, 15), anchor=W)
+        title.grid(row=0, column=0, sticky=W, pady=(0, 10))
         
         parent.grid_columnconfigure(0, weight=1)
         parent.grid_columnconfigure(1, weight=1)
@@ -140,7 +141,7 @@ class ToolsPage:
         row, col = 1, 0
         for page in self.pages:
             card = self._draw_page_card(parent, page)
-            card.grid(row=row, column=col, sticky=ttk.NSEW, padx=(0, 5) if col == 0 else (5, 0), pady=5)
+            card.grid(row=row, column=col, sticky=NSEW, padx=(0, 5) if col == 0 else (5, 0), pady=5)
             col += 1
             if col > 1:
                 col = 0

--- a/gui/pages/tools/user_lookup_page.py
+++ b/gui/pages/tools/user_lookup_page.py
@@ -1,5 +1,6 @@
 import sys
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from gui.components import RoundedFrame, ToolPage
 from gui.helpers import Style
 
@@ -24,17 +25,17 @@ class UserLookupPage(ToolPage):
         if self.search_results_widget:
             self.search_results_widget.destroy()
         self.search_results_widget = self._draw_search_results(self.wrapper)
-        self.search_results_widget.pack(side=ttk.TOP, fill=ttk.BOTH, expand=True)
+        self.search_results_widget.pack(side=TOP, fill=BOTH, expand=True)
 
     def _draw_search_bar(self, parent):
         entry_wrapper = RoundedFrame(parent, radius=(15, 15, 15, 15), bootstyle="dark.TFrame")
-        # entry_wrapper.pack(fill=ttk.BOTH)
+        # entry_wrapper.pack(fill=BOTH)
         
         placeholder_text = "Search a Discord user ID..."
         
         def on_focus_in(event):
             if self.search_entry.get() == placeholder_text:
-                self.search_entry.delete(0, ttk.END)
+                self.search_entry.delete(0, END)
                 self.search_entry.configure(foreground="white")
                 
         def on_focus_out(event):
@@ -43,7 +44,7 @@ class UserLookupPage(ToolPage):
                 self.search_entry.configure(foreground="grey")
         
         self.search_entry = ttk.Entry(entry_wrapper, bootstyle="dark.TFrame", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
-        self.search_entry.grid(row=0, column=0, sticky=ttk.EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
+        self.search_entry.grid(row=0, column=0, sticky=EW, padx=(18, 0), pady=10, columnspan=2, ipady=10)
         self.search_entry.configure(foreground="grey")
         self.search_entry.insert(0, placeholder_text)
         self.search_entry.bind("<FocusIn>", on_focus_in)
@@ -51,7 +52,7 @@ class UserLookupPage(ToolPage):
         self.search_entry.bind("<Return>", lambda e: self._search_user(self.search_entry.get()))
         
         search_button = ttk.Label(entry_wrapper, image=self.images.get("search"), style="dark.TButton")
-        search_button.grid(row=0, column=2, sticky=ttk.E, padx=(0, 10), pady=10)
+        search_button.grid(row=0, column=2, sticky=E, padx=(0, 10), pady=10)
         search_button.bind("<Button-1>", lambda e: self._search_user(self.search_entry.get()))
         
         entry_wrapper.columnconfigure(1, weight=1)
@@ -64,36 +65,36 @@ class UserLookupPage(ToolPage):
         if self.user_avatar:
             avatar_label = ttk.Label(wrapper, image=self.user_avatar)
             avatar_label.configure(background=self.root.style.colors.get("dark"))
-            avatar_label.grid(row=0, column=1, sticky=ttk.E, padx=15, pady=15)
+            avatar_label.grid(row=0, column=1, sticky=E, padx=15, pady=15)
             wrapper.grid_columnconfigure(1, weight=1)
             
         if self.user:
             user_info_wrapper = ttk.Frame(wrapper, style="dark.TFrame")
-            user_info_wrapper.grid(row=0, column=0, sticky=ttk.NSEW, padx=(15, 0), pady=15)
+            user_info_wrapper.grid(row=0, column=0, sticky=NSEW, padx=(15, 0), pady=15)
             
             display_name = ttk.Label(user_info_wrapper, text=self.user.display_name, font=("Host Grotesk", 16 if sys.platform != "darwin" else 20, "bold"))
             display_name.configure(background=self.root.style.colors.get("dark"))
-            display_name.grid(row=0, column=1, sticky=ttk.W)
+            display_name.grid(row=0, column=1, sticky=W)
             
             if self.user.bot:
                 bot_tag = ttk.Label(user_info_wrapper, text="Bot", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13), foreground="red")
                 bot_tag.configure(background=self.root.style.colors.get("dark"))
-                bot_tag.grid(row=0, column=2, sticky=ttk.W)
+                bot_tag.grid(row=0, column=2, sticky=W)
 
             username = ttk.Label(user_info_wrapper, text=f"@{self.user.name}", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
             username.configure(background=self.root.style.colors.get("dark"), foreground=Style.LIGHT_GREY.value)
-            username.grid(row=1, column=1, sticky=ttk.W)
+            username.grid(row=1, column=1, sticky=W)
             
             user_id = ttk.Label(user_info_wrapper, text=f"ID: {self.user.id}", font=("Host Grotesk", 12 if sys.platform != "darwin" else 13))
             user_id.configure(background=self.root.style.colors.get("dark"))
-            user_id.grid(row=2, column=1, sticky=ttk.W, pady=(5, 0))
+            user_id.grid(row=2, column=1, sticky=W, pady=(5, 0))
         
         return wrapper
 
     def draw_content(self, wrapper):
         self.wrapper = wrapper
         search_bar = self._draw_search_bar(self.wrapper)
-        search_bar.pack(side=ttk.TOP, fill=ttk.X, pady=(0, 10))
+        search_bar.pack(side=TOP, fill=X, pady=(0, 10))
 
         self.search_results_widget = self._draw_search_results(self.wrapper)
-        self.search_results_widget.pack(side=ttk.TOP, fill=ttk.BOTH, expand=True)
+        self.search_results_widget.pack(side=TOP, fill=BOTH, expand=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ colorama
 git+https://github.com/dolfies/discord.py-self.git
 Faker
 requests
-pillow
+pillow>=11
 pystyle
 psutil
 pycryptodome
-ttkbootstrap==1.14.2
+ttkbootstrap==1.20.4
 pyinstaller
 # git+https://github.com/tomlin7/cupcake.git
 cupcake-editor


### PR DESCRIPTION
Running `pip install -r requirements.txt` on Python 3.14 fails because it fails on building the version of Pillow that was being installed. Pillow isn't being pinned, the problem is that for ttkbootstrap==1.14.2, the version of Pillow requires has to be like pillow<11,>=10 and so I had to bump up the version of ttkbootstrap. Here is everything I changed:
-Bumped up ttkbootstrap 1.14.2 --> 1.20.4 so the project can use any pillow<13
-Pinned pillow>=11 in the requirements.txt
-Some things were changed from 1.14.2, so I had to replace them
ttk.tk and ttk.font were removed so instead of those I did `import tkinter` and `import tkinter.font`
doing stuff like `ttk.BOTH`, `ttk.LEFT`, `ttk.END` were removed so instead I had to do `from ttkbootstrap.constants import *`