### PR TITLE
Auto-elevate to admin for font installation on Windows

### DIFF
--- a/ghost.py
+++ b/ghost.py
@@ -15,7 +15,7 @@ if getattr(sys, 'frozen', False):
 
 from utils.files import get_application_support
 from utils.config import Config
-from utils import startup_check, check_fonts, console, load_fonts
+from utils import startup_check, check_fonts, console, load_fonts, is_admin, run_elevated, relaunch_normal
 from bot.controller import BotController
 
 
@@ -25,6 +25,12 @@ def parse_args():
         "--headless",
         action="store_true",
         help="Force CLI mode instead of the GUI",
+    )
+    parser.add_argument(
+        "--install-fonts",
+        action="store_true",
+        dest="install_fonts",
+        help="Install required fonts and relaunch",
     )
     return parser.parse_args()
 
@@ -78,8 +84,14 @@ def main():
         run_gui()
     elif check_fonts():
         run_gui()
+    elif args.install_fonts:
+        load_fonts()
+        if check_fonts():
+            relaunch_normal()
     else:
-        # FontCheckGUI().run()
+        if sys.platform == "win32" and not is_admin():
+            run_elevated()
+            return
         load_fonts()
         run_gui()
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,5 +4,5 @@ from .webhook import Webhook
 from .config import Config, RichPresence, Sniper, Theme, Token
 from .console import get_formatted_time
 from .files import resource_path
-from .fonts import load_fonts, uninstall_fonts, check_fonts, get_fonts
+from .fonts import load_fonts, uninstall_fonts, check_fonts, get_fonts, is_admin, run_elevated, relaunch_normal
 from .defaults import DEFAULT_CONFIG, DEFAULT_THEME, DEFAULT_RPC, DEFAULT_SCRIPT

--- a/utils/fonts.py
+++ b/utils/fonts.py
@@ -233,3 +233,26 @@ def uninstall_mac_font(font_name):
         print(f"Font '{font_name}' removed from Font Book.")
     except subprocess.CalledProcessError:
         print(f"Failed to remove font '{font_name}' from Font Book.")
+
+def is_admin():
+    if sys.platform != "win32":
+        return True
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except Exception:
+        return False
+
+def run_elevated():
+    if getattr(sys, 'frozen', False):
+        params = " ".join(sys.argv[1:] + ["--install-fonts"])
+    else:
+        params = " ".join([sys.argv[0]] + sys.argv[1:] + ["--install-fonts"])
+    ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, params, os.getcwd(), 1)
+
+def relaunch_normal():
+    if getattr(sys, 'frozen', False):
+        cmd = [sys.executable]
+    else:
+        cmd = [sys.executable, sys.argv[0]]
+    args = [arg for arg in sys.argv[1:] if arg != "--install-fonts"]
+    subprocess.Popen(cmd + args)


### PR DESCRIPTION
When fonts are missing, the app now automatically requests admin rights on Windows, installs the fonts, then drops back to normal privileges. This eliminates the manual way of doing "Run as Administrator" on the Ghost executable.